### PR TITLE
Ke/use lfxstatic cdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 13.1.2
+
+### Features
+
+### Fixes
+
+- Reference dependency `zone.js` from `lfxstatic.com`
+  - `<script src='https://lfxstatic.com/npm/-/zone.js@0.11.4/bundles/zone.umd.min.js'></script>`
+- `[lf-documentation]` reference style sheets from `lfxstatic.com`
+- Reference language resources from `lfxstatic.com`
+
+### Chore & Maintenance
+
 ## 13.1.1
 
 ### Features

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,9 +40,9 @@ const SOURCEMAP_POLYFILLS_URL = '//# sourceMappingURL=polyfills.js.map';
 const COMPILED_GETTING_STARTED_FILE_PATH = './dist/lf-documentation/lf-documentation.js';
 const BUILT_INDEX_HTML_FILEPATH = './dist/lf-documentation/index.html';
 const OLD_LF_STYLE_SHEET_PATH = './lf-laserfiche-lite.css';
-const NEW_LF_STYLE_SHEET_PATH = 'https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css';
+const NEW_LF_STYLE_SHEET_PATH = 'https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css';
 const OLD_MS_OFFICE_STYLE_SHEET_PATH = './lf-ms-office-lite.css';
-const NEW_MS_OFFICE_STYLE_SHEET_PATH = 'https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css';
+const NEW_MS_OFFICE_STYLE_SHEET_PATH = 'https://https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css';
 
 async function replaceScriptsInIndexHtml(){
   src(INDEX_HTML_FILEPATH, {base: './'})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ const BUILT_INDEX_HTML_FILEPATH = './dist/lf-documentation/index.html';
 const OLD_LF_STYLE_SHEET_PATH = './lf-laserfiche-lite.css';
 const NEW_LF_STYLE_SHEET_PATH = 'https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css';
 const OLD_MS_OFFICE_STYLE_SHEET_PATH = './lf-ms-office-lite.css';
-const NEW_MS_OFFICE_STYLE_SHEET_PATH = 'https://https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css';
+const NEW_MS_OFFICE_STYLE_SHEET_PATH = 'https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css';
 
 async function replaceScriptsInIndexHtml(){
   src(INDEX_HTML_FILEPATH, {base: './'})

--- a/package-lock.json
+++ b/package-lock.json
@@ -4908,12 +4908,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/async-each": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-      "dev": true
-    },
     "node_modules/async-settle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
@@ -5208,16 +5202,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -8569,13 +8553,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -9206,46 +9183,73 @@
       }
     },
     "node_modules/glob-stream": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-      "integrity": "sha512-uMbLGAP3S2aDOHUDfdoYcdIePUCfysbAd0IAoWVZbeGU/oNQ8asHVSshLDJUPWxfzj8zsCG7/XeHPHTtow0nsw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-7.0.0.tgz",
+      "integrity": "sha512-evR4kvr6s0Yo5t4CD4H171n4T8XcnPFznvsbeN8K9FPzc0Q0wYqcOWyGtck2qcvJSLXKnU6DnDyfmbDDabYvRQ==",
       "dev": true,
       "dependencies": {
-        "extend": "^3.0.0",
-        "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
+        "extend": "^3.0.2",
+        "glob": "^7.2.0",
+        "glob-parent": "^6.0.2",
         "is-negated-glob": "^1.0.0",
-        "ordered-read-streams": "^1.0.0",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.1.5",
-        "remove-trailing-separator": "^1.0.1",
-        "to-absolute-glob": "^2.0.0",
-        "unique-stream": "^2.0.2"
+        "ordered-read-streams": "^1.0.1",
+        "pumpify": "^2.0.1",
+        "readable-stream": "^3.6.0",
+        "remove-trailing-separator": "^1.1.0",
+        "to-absolute-glob": "^2.0.2",
+        "unique-stream": "^2.3.1"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob-stream/node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
       }
     },
     "node_modules/glob-stream/node_modules/glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/glob-stream/node_modules/is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.0"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob-stream/node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "dev": true,
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
+    "node_modules/glob-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -9262,7 +9266,7 @@
       "dependencies": {
         "anymatch": "^2.0.0",
         "async-done": "^1.2.0",
-        "chokidar": "^2.0.0",
+        "chokidar": "^3.5.1",
         "is-negated-glob": "^1.0.0",
         "just-debounce": "^1.0.0",
         "normalize-path": "^3.0.0",
@@ -9290,15 +9294,6 @@
       "dependencies": {
         "remove-trailing-separator": "^1.0.1"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob-watcher/node_modules/binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9336,29 +9331,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/glob-watcher/node_modules/chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
-      "dev": true,
-      "dependencies": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      },
-      "optionalDependencies": {
-        "fsevents": "^1.2.7"
-      }
-    },
     "node_modules/glob-watcher/node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -9381,59 +9353,6 @@
       "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob-watcher/node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/glob-watcher/node_modules/glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/glob-watcher/node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob-watcher/node_modules/is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
-      "dev": true,
-      "dependencies": {
-        "binary-extensions": "^1.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -9503,20 +9422,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob-watcher/node_modules/readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/glob-watcher/node_modules/to-regex-range": {
@@ -9631,7 +9536,7 @@
       "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
       "dev": true,
       "dependencies": {
-        "glob-watcher": "^5.0.3",
+        "glob-watcher": "^5.0.5",
         "gulp-cli": "^2.2.0",
         "undertaker": "^1.2.1",
         "vinyl-fs": "^3.0.0"
@@ -12638,13 +12543,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
-    "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -13942,12 +13840,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -17745,16 +17637,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/upath": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
@@ -17913,7 +17795,7 @@
       "dev": true,
       "dependencies": {
         "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
+        "glob-stream": "^7.0.0",
         "graceful-fs": "^4.0.0",
         "is-valid-glob": "^1.0.0",
         "lazystream": "^1.0.0",
@@ -22140,12 +22022,6 @@
         "stream-exhaust": "^1.0.1"
       }
     },
-    "async-each": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-      "dev": true
-    },
     "async-settle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
@@ -22353,16 +22229,6 @@
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
       "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bl": {
       "version": "4.1.0",
@@ -24838,13 +24704,6 @@
         "flat-cache": "^3.0.4"
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -25332,40 +25191,64 @@
       }
     },
     "glob-stream": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-      "integrity": "sha512-uMbLGAP3S2aDOHUDfdoYcdIePUCfysbAd0IAoWVZbeGU/oNQ8asHVSshLDJUPWxfzj8zsCG7/XeHPHTtow0nsw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-7.0.0.tgz",
+      "integrity": "sha512-evR4kvr6s0Yo5t4CD4H171n4T8XcnPFznvsbeN8K9FPzc0Q0wYqcOWyGtck2qcvJSLXKnU6DnDyfmbDDabYvRQ==",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
+        "extend": "^3.0.2",
+        "glob": "^7.2.0",
+        "glob-parent": "^6.0.2",
         "is-negated-glob": "^1.0.0",
-        "ordered-read-streams": "^1.0.0",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.1.5",
-        "remove-trailing-separator": "^1.0.1",
-        "to-absolute-glob": "^2.0.0",
-        "unique-stream": "^2.0.2"
+        "ordered-read-streams": "^1.0.1",
+        "pumpify": "^2.0.1",
+        "readable-stream": "^3.6.0",
+        "remove-trailing-separator": "^1.1.0",
+        "to-absolute-glob": "^2.0.2",
+        "unique-stream": "^2.3.1"
       },
       "dependencies": {
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
           }
         },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-glob": "^4.0.3"
+          }
+        },
+        "pumpify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+          "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+          "dev": true,
+          "requires": {
+            "duplexify": "^4.1.1",
+            "inherits": "^2.0.3",
+            "pump": "^3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -25384,7 +25267,7 @@
       "requires": {
         "anymatch": "^2.0.0",
         "async-done": "^1.2.0",
-        "chokidar": "^2.0.0",
+        "chokidar": "^3.5.1",
         "is-negated-glob": "^1.0.0",
         "just-debounce": "^1.0.0",
         "normalize-path": "^3.0.0",
@@ -25411,12 +25294,6 @@
               }
             }
           }
-        },
-        "binary-extensions": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-          "dev": true
         },
         "braces": {
           "version": "2.3.2",
@@ -25447,26 +25324,6 @@
             }
           }
         },
-        "chokidar": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-          "dev": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -25488,47 +25345,6 @@
                 "is-extendable": "^0.1.0"
               }
             }
-          }
-        },
-        "fsevents": {
-          "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-          "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
-          "dev": true,
-          "requires": {
-            "binary-extensions": "^1.0.0"
           }
         },
         "is-extendable": {
@@ -25582,17 +25398,6 @@
               "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
               "dev": true
             }
-          }
-        },
-        "readdirp": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
           }
         },
         "to-regex-range": {
@@ -25687,7 +25492,7 @@
       "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
       "dev": true,
       "requires": {
-        "glob-watcher": "^5.0.3",
+        "glob-watcher": "^5.0.5",
         "gulp-cli": "^2.2.0",
         "undertaker": "^1.2.1",
         "vinyl-fs": "^3.0.0"
@@ -27977,13 +27782,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
-    "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-      "dev": true,
-      "optional": true
-    },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -28984,12 +28782,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
-      "dev": true
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
       "dev": true
     },
     "path-exists": {
@@ -31819,12 +31611,6 @@
         }
       }
     },
-    "upath": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true
-    },
     "update-browserslist-db": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
@@ -31942,7 +31728,7 @@
       "dev": true,
       "requires": {
         "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
+        "glob-stream": "^7.0.0",
         "graceful-fs": "^4.0.0",
         "is-valid-glob": "^1.0.0",
         "lazystream": "^1.0.0",

--- a/projects/lf-documentation/karma.conf.js
+++ b/projects/lf-documentation/karma.conf.js
@@ -33,6 +33,6 @@ module.exports = function (config) {
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true,
-    files: ["https://cdn.jsdelivr.net/npm/zone.js@0.11.4/bundles/zone.umd.min.js", "../../dist/lf-cdn/lf-ui-components.js"]
+    files: ["https://lfxstatic.com/npm/-/zone.js@0.11.4/bundles/zone.umd.min.js", "../../dist/lf-cdn/lf-ui-components.js"]
   });
 };

--- a/projects/lf-documentation/src/app/getting-started/getting-started.component.html
+++ b/projects/lf-documentation/src/app/getting-started/getting-started.component.html
@@ -22,9 +22,9 @@
     <p class="documentation-text">Add the following script tags to <code>index.html</code>.</p>
     <pre class="code-container">
 <span class="code-html-tagname"> &lt;script </span><span class="code-html-attribute-name">src</span><span>=</span><span class="code-html-attribute-value"
-      >"https://cdn.jsdelivr.net/npm/zone.js@0.11.4/bundles/zone.umd.min.js"</span><span class="code-html-tagname">&gt;&lt;/script&gt;</span>
+      >"https://lfxstatic.com/npm/-/zone.js@0.11.4/bundles/zone.umd.min.js"</span><span class="code-html-tagname">&gt;&lt;/script&gt;</span>
 <span class="code-html-tagname"> &lt;script </span><span class="code-html-attribute-name">src</span><span>=</span><span class="code-html-attribute-value"
->"https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ui-components.js"</span><span class="code-html-attribute-name"
+>"https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ui-components.js"</span><span class="code-html-attribute-name"
 > defer</span><span class="code-html-tagname">&gt;&lt;/script&gt;</span>
 </pre>
     <p class="documentation-text">
@@ -48,7 +48,7 @@
         <span class="code-html-attribute-name">href</span>
         <span>=</span>
         <span class="code-html-attribute-value"
-          >"https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css"
+          >"https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css"
         </span>
         <span class="code-html-attribute-name">rel</span>
         <span>=</span>
@@ -64,7 +64,7 @@
         <span class="code-html-attribute-name">href</span>
         <span>=</span>
         <span class="code-html-attribute-value"
-          >"https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css"
+          >"https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css"
         </span>
         <span class="code-html-attribute-name">rel</span>
         <span>=</span>
@@ -84,7 +84,7 @@
         <span class="code-html-attribute-name">href</span>
         <span>=</span>
         <span class="code-html-attribute-value"
-          >"https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/indigo-pink.css"
+          >"https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/indigo-pink.css"
         </span>
         <span class="code-html-attribute-name">rel</span>
         <span>=</span>

--- a/projects/lf-documentation/src/app/styling-documentation/styling-documentation.component.html
+++ b/projects/lf-documentation/src/app/styling-documentation/styling-documentation.component.html
@@ -34,10 +34,10 @@
     <button class="lf-button" (click)="showCode('styles.css', 'import')">styles.css</button>
     <div>
         <div id="index.html" class="import tab-content" style="display: none;">
-            <code>&lt;link id="lf-stylesheet" href="https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css" rel="stylesheet" /&gt;</code>
+            <code>&lt;link id="lf-stylesheet" href="https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css" rel="stylesheet" /&gt;</code>
         </div>
         <div id="styles.css" class="import tab-content" style="display: none;">
-            <code>@import "https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css";</code>
+            <code>@import "https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css";</code>
         </div>
     </div>
 </app-card>
@@ -118,12 +118,12 @@
             <pre><code>
   setThemeLaserfiche() &#123;
     const stylesheet = document.getElementById('lf-stylesheet');
-    stylesheet.setAttribute('href', 'https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css');
+    stylesheet.setAttribute('href', 'https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-laserfiche-lite.css');
   &#125;
 
   setThemeMicrosoft() &#123;
     const stylesheet = document.getElementById('lf-stylesheet');
-    stylesheet.setAttribute('href', 'https://cdn.jsdelivr.net/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css');
+    stylesheet.setAttribute('href', 'https://lfxstatic.com/npm/@laserfiche/lf-ui-components@NPM_VERSION/cdn/lf-ms-office-lite.css');
   &#125;
 
   removeTheme() &#123;

--- a/projects/styles/lf-laserfiche-lite/sass/_material.scss
+++ b/projects/styles/lf-laserfiche-lite/sass/_material.scss
@@ -5,14 +5,14 @@
     font-family: 'Material Icons';
     font-style: normal;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/regular-filled.woff2) format('woff2');
+    src: url(https://lfxstatic.com/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/regular-filled.woff2) format('woff2');
 }
 
 @font-face {
   font-family: 'Material Icons Outlined';
   font-style: normal;
   font-weight: 400;
-  src: url(https://cdn.jsdelivr.net/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/outlined.woff2) format('woff2');
+  src: url(https://lfxstatic.com/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/outlined.woff2) format('woff2');
 }
 
 .material-icons {

--- a/projects/styles/lf-ms-office/sass/_material.scss
+++ b/projects/styles/lf-ms-office/sass/_material.scss
@@ -3,14 +3,14 @@
     font-family: 'Material Icons';
     font-style: normal;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/regular-filled.woff2) format('woff2');
+    src: url(https://lfxstatic.com/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/regular-filled.woff2) format('woff2');
 }
 
 @font-face {
   font-family: 'Material Icons Outlined';
   font-style: normal;
   font-weight: 400;
-  src: url(https://cdn.jsdelivr.net/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/outlined.woff2) format('woff2');
+  src: url(https://lfxstatic.com/npm/@laserfiche/lf-resource-library@4/resources/google-material-design-icons/outlined.woff2) format('woff2');
 }
 
 .material-icons {

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-field/date-field.component.spec.ts
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-field/date-field.component.spec.ts
@@ -233,7 +233,7 @@ describe('DateFieldComponent', () => {
     optionalDateComponent.LOCALE_DATE.subscribe((val) => {
       value = val;
     });
-    await optionalDateComponent.localizationService.setLanguageAsync('es');
+    await optionalDateComponent.localizationService.setLanguageAsync('es-MX');
 
     // assert
     await CoreUtils.waitForConditionAsync(

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-time-field/date-time-field.component.spec.ts
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-time-field/date-time-field.component.spec.ts
@@ -212,7 +212,7 @@ describe('DateTimeFieldComponent', () => {
     optionalDateTimeComponent.LOCALE_DATE_TIME.subscribe((val) => {
       value = val;
     });
-    await optionalDateTimeComponent.localizationService.setLanguageAsync('es');
+    await optionalDateTimeComponent.localizationService.setLanguageAsync('es-MX');
 
     // assert
     await CoreUtils.waitForConditionAsync(

--- a/projects/ui-components/shared/app-localization.service.ts
+++ b/projects/ui-components/shared/app-localization.service.ts
@@ -8,7 +8,7 @@ import { concatMap, map, startWith } from 'rxjs/operators';
   providedIn: 'root',
 })
 export class AppLocalizationService {
-  resourceUrl = 'https://cdn.jsdelivr.net/npm/@laserfiche/lf-resource-library@4/resources/laserfiche-base';
+  resourceUrl = 'https://lfxstatic.com/npm/@laserfiche/lf-resource-library@4/resources/laserfiche-base';
   localizationService = new LfLocalizationService();
   internalGetString: Subject<void> = new Subject<void>();
 


### PR DESCRIPTION
- use lfxstatic in place for jsdelivr
- fix security warning. bumped version of chokidar to v3 from v2 and glob-stream to v7 from v6 
  - https://github.com/paulmillr/chokidar#changelog
  - https://github.com/gulpjs/glob-stream/blob/master/CHANGELOG.md