### PR TITLE
Alex/update pipelines

### DIFF
--- a/.github/workflows/veracode-14x.yml
+++ b/.github/workflows/veracode-14x.yml
@@ -21,7 +21,9 @@ jobs:
           fi
 
       - uses: actions/checkout@v3
-          ref: ${{github.sha}}
+        with:
+          ref: ${{ github.sha }}
+
       - name: Echo build number
         run: echo ${{github.run_id}}
 

--- a/.github/workflows/veracode-14x.yml
+++ b/.github/workflows/veracode-14x.yml
@@ -3,7 +3,7 @@ name: lf-ui-components-veracode-14x
 on:
   # Allows you to run this workflow manually from the Actions tab
   push:
-    branches: ["14.x"]
+    branches: ["alex/update-pipelines"]
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * 6'

--- a/.github/workflows/veracode-14x.yml
+++ b/.github/workflows/veracode-14x.yml
@@ -3,7 +3,7 @@ name: lf-ui-components-veracode-14x
 on:
   # Allows you to run this workflow manually from the Actions tab
   push:
-    branches: ["alex/update-pipelines"]
+    branches: ["14.x"]
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * 6'
@@ -13,7 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout 14.x branch
+        uses: actions/checkout@v3
         with:
           ref: 14.x
 

--- a/.github/workflows/veracode-14x.yml
+++ b/.github/workflows/veracode-14x.yml
@@ -3,7 +3,7 @@ name: lf-ui-components-veracode-14x
 on:
   # Allows you to run this workflow manually from the Actions tab
   push:
-    branches: ["alex/update-pipelines"]
+    branches: ["14.x"]
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * 6'
@@ -13,16 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Exit if the branch is not 14.x
-        run: |
-          if [[ "${{ github.ref }}" != "refs/heads/14.x" ]]; then
-            echo "Branch is not 14.x, exiting."
-            exit -1
-          fi
-
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.sha }}
+          ref: 14.x
 
       - name: Echo build number
         run: echo ${{github.run_id}}

--- a/.github/workflows/veracode-14x.yml
+++ b/.github/workflows/veracode-14x.yml
@@ -1,0 +1,89 @@
+name: lf-ui-components-veracode-14x
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  push:
+    branches: ["14.x"]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 6'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 14.x
+
+      - name: Exit if the branch is not 14.x
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/14.x" ]]; then
+            echo "Branch is not 14.x, exiting."
+            exit 0
+          fi
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Npm run build-ui-components
+        run: npm run build-ui-components-dev
+
+      - name: Npm run build-lf-cdn-dev
+        run: npm run build-lf-cdn-dev
+
+      - name: Npm run build-lf-documentation-dev
+        run: npm run build-lf-documentation-dev
+
+      - name: Npm run sass-lf
+        run: npm run sass-lf
+
+      - name: Npm run sass-ms
+        run: npm run sass-ms
+
+      - name: 'create an empty ./dist/ui-components/cdn folder'
+        run: 'mkdir -p ./dist/ui-components/cdn'
+
+      - name: 'move js to ui-components/cdn'
+        run: mv -t ../ui-components/cdn main.js runtime.js polyfills.js main.js.map runtime.js.map polyfills.js.map
+        working-directory: dist/lf-cdn
+
+      - name: 'move lf-documentation/styles to ui-components/cdn'
+        run: mv -t  ../ui-components/cdn/ lf-laserfiche-lite.css lf-ms-office-lite.css lf-laserfiche-lite.css.map lf-ms-office-lite.css.map
+        working-directory: dist/lf-documentation
+      
+      - name: 'create an empty ./veracode folder'
+        run: 'mkdir -p ./veracode'
+        
+      - name: 'Compress UI Components'
+        run: tar -czvf ./veracode/ui-components.tar.gz ./dist/ui-components
+
+      - name: 'Compress Documentation'
+        run: tar -czvf ./veracode/lf-documentation.tar.gz ./dist/lf-documentation
+
+      - name: Veracode Upload And Scan (Static application security testing)
+        uses: veracode/veracode-uploadandscan-action@0.2.6
+        with:
+          appname: 'lf-ui-components-v14'
+          createprofile: true
+          filepath: 'veracode'
+          vid: '${{ secrets.VERACODE_API_ID }}'
+          vkey: '${{ secrets.VERACODE_API_KEY }}'
+          teams: 'GitHub - Open Source'
+
+      - name: Run Veracode Software Composition Analysis (srccclr)
+        env:
+          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_TOKEN_UICOMPONENTS_14 }}
+        uses: veracode/veracode-sca@v2.1.6
+        with:
+          create-issues: false
+          allow-dirty: true

--- a/.github/workflows/veracode-14x.yml
+++ b/.github/workflows/veracode-14x.yml
@@ -13,10 +13,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: 14.x
-
       - name: Exit if the branch is not 14.x
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/14.x" ]]; then
@@ -24,6 +20,8 @@ jobs:
             exit 0
           fi
 
+      - uses: actions/checkout@v3
+          ref: ${{github.sha}}
       - name: Echo build number
         run: echo ${{github.run_id}}
 

--- a/.github/workflows/veracode-14x.yml
+++ b/.github/workflows/veracode-14x.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           if [[ "${{ github.ref }}" != "refs/heads/14.x" ]]; then
             echo "Branch is not 14.x, exiting."
-            exit 0
+            exit -1
           fi
 
       - uses: actions/checkout@v3

--- a/.github/workflows/veracode-15x.yml
+++ b/.github/workflows/veracode-15x.yml
@@ -1,0 +1,89 @@
+name: lf-ui-components-veracode-15x
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  push:
+    branches: ["15.x"]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 6"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: 15.x
+
+      - name: Exit if the branch is not 15.x
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/15.x" ]]; then
+            echo "Branch is not 15.x, exiting."
+            exit 0
+          fi
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: npm ci
+        run: npm ci
+
+      - name: Npm run build-ui-components
+        run: npm run build-ui-components-dev
+
+      - name: Npm run build-lf-cdn-dev
+        run: npm run build-lf-cdn-dev
+
+      - name: Npm run build-lf-documentation-dev
+        run: npm run build-lf-documentation-dev
+
+      - name: Npm run sass-lf
+        run: npm run sass-lf
+
+      - name: Npm run sass-ms
+        run: npm run sass-ms
+
+      - name: "create an empty ./dist/ui-components/cdn folder"
+        run: "mkdir -p ./dist/ui-components/cdn"
+
+      - name: "move js to ui-components/cdn"
+        run: mv -t ../ui-components/cdn main.js runtime.js polyfills.js main.js.map runtime.js.map polyfills.js.map
+        working-directory: dist/lf-cdn
+
+      - name: "move lf-documentation/styles to ui-components/cdn"
+        run: mv -t  ../ui-components/cdn/ lf-laserfiche-lite.css lf-ms-office-lite.css lf-laserfiche-lite.css.map lf-ms-office-lite.css.map
+        working-directory: dist/lf-documentation
+
+      - name: "create an empty ./veracode folder"
+        run: "mkdir -p ./veracode"
+
+      - name: "Compress UI Components"
+        run: tar -czvf ./veracode/ui-components.tar.gz ./dist/ui-components
+
+      - name: "Compress Documentation"
+        run: tar -czvf ./veracode/lf-documentation.tar.gz ./dist/lf-documentation
+
+      - name: Veracode Upload And Scan (Static application security testing)
+        uses: veracode/veracode-uploadandscan-action@0.2.6
+        with:
+          appname: "lf-ui-components-v15"
+          createprofile: true
+          filepath: "veracode"
+          vid: "${{ secrets.VERACODE_API_ID }}"
+          vkey: "${{ secrets.VERACODE_API_KEY }}"
+          teams: "GitHub - Open Source"
+
+      - name: Run Veracode Software Composition Analysis (srccclr)
+        env:
+          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_TOKEN_UICOMPONENTS_15 }}
+        uses: veracode/veracode-sca@v2.1.6
+        with:
+          create-issues: false
+          allow-dirty: true

--- a/.github/workflows/veracode-15x.yml
+++ b/.github/workflows/veracode-15x.yml
@@ -13,16 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout 15.x branch
+        uses: actions/checkout@v3
         with:
           ref: 15.x
-
-      - name: Exit if the branch is not 15.x
-        run: |
-          if [[ "${{ github.ref }}" != "refs/heads/15.x" ]]; then
-            echo "Branch is not 15.x, exiting."
-            exit 0
-          fi
 
       - name: Echo build number
         run: echo ${{github.run_id}}


### PR DESCRIPTION
Add 14.x and 15.x veracode pipelines to 16.x branch so that they can be run on a schedule. Currently GitHub doesn't support a different way to do this. 

These pipelines will always run off of 14.x or 15.x even if you run them off a different branch. If you need to run it off a different branch you'd have to alter the pipeline that is on the actual 14.x branch anyways 