### PR TITLE
Fixing nested feedback modal window focus

### DIFF
--- a/projects/ui-components/lf-user-feedback/user-feedback-dialog/user-feedback-dialog.component.ts
+++ b/projects/ui-components/lf-user-feedback/user-feedback-dialog/user-feedback-dialog.component.ts
@@ -8,6 +8,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  HostListener,
   OnDestroy,
   Output,
   ViewChild,
@@ -65,9 +66,13 @@ export class UserFeedbackDialogComponent implements AfterViewInit, OnDestroy {
     FEEDBACK: this.localizationService.getStringLaserficheObservable('FEEDBACK'),
     CLOSE: this.localizationService.getStringLaserficheObservable('CLOSE'),
     THANK_YOU_FOR_SUBMISSION: this.localizationService.getStringLaserficheObservable('THANK_YOU_FOR_SUBMISSION'),
-    IF_YOUD_LIKE_TO_JOIN_OUR_CUSTOMER_PANEL: this.localizationService.getStringComponentsObservable(
-      'IF_YOUD_LIKE_TO_JOIN_OUR_CUSTOMER_PANEL'
-    ).pipe(map((value: string) => {return `${value} `;})),
+    IF_YOUD_LIKE_TO_JOIN_OUR_CUSTOMER_PANEL: this.localizationService
+      .getStringComponentsObservable('IF_YOUD_LIKE_TO_JOIN_OUR_CUSTOMER_PANEL')
+      .pipe(
+        map((value: string) => {
+          return `${value} `;
+        })
+      ),
     PLEASE_CLICK_HERE: this.localizationService.getStringComponentsObservable('PLEASE_CLICK_HERE'),
     SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN_LATER: this.localizationService.getStringLaserficheObservable(
       'SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN_LATER'
@@ -82,7 +87,7 @@ export class UserFeedbackDialogComponent implements AfterViewInit, OnDestroy {
     public dialogRef: MatDialogRef<UserFeedbackDialogComponent>,
     private ref: ChangeDetectorRef,
     private localizationService: AppLocalizationService
-  ) { }
+  ) {}
 
   ngAfterViewInit() {
     const elem = document.getElementById('lf-user-feedback-feedback-mode-button');
@@ -100,15 +105,20 @@ export class UserFeedbackDialogComponent implements AfterViewInit, OnDestroy {
   onClickFeedback(): void {
     this.dialogState = FeedbackDialogState.FEEDBACK;
     this.USER_FEEDBACK_TITLE = this.localizedStrings.FEEDBACK;
-    document.getElementById('feedback-suggestion-textbox')?.focus();
+    setTimeout(() => document.getElementById('feedback-suggestion-textbox')?.focus());
     this.onTextChanges();
   }
 
   onClickSuggestion(): void {
     this.dialogState = FeedbackDialogState.SUGGESTION;
     this.USER_FEEDBACK_TITLE = this.localizedStrings.SUGGESTION;
-    document.getElementById('feedback-suggestion-textbox')?.focus();
+    setTimeout(() => document.getElementById('feedback-suggestion-textbox')?.focus());
     this.onTextChanges();
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscKey(event: KeyboardEvent) {
+    this.dialogRef.close();
   }
 
   private onTextChanges(): void {


### PR DESCRIPTION
This PR fixes two problems that can improve the accessibility:

1. The keyboard navigation is not working properly in the nested modal window

> Steps to reproduce:
> 
> - There is a root panel that uses the Feedback button.
> - Open the Feedback modal window and select either the Feedback or the Suggestion option from the list
> - Start the keyboard navigation
> - The focus starts on the root panel instead of the modal Feedback/Suggestion modal.
> 

**Expected behavior**: The focus should remain inside the feedback dialog window.

2. The Escape key press was not handled at all. 

> Steps to reproduce:
> - open the Feedback modal window
> - press the Escape button
> - the Feedback modal window remains open, but if I navigate using the keyboard the focus starts on the root panel.
> 

**Expected behavior**: The Feedback modal should close.

This PR improves the keyboard navigation of the feedback dialog component and handles the Escape key press.
