### PR TITLE
Fix test report creation fail on pull request runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,13 +73,14 @@ jobs:
         run: npm run test:ci
 
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         if: always()
         with:
           name: Jest Test Results
           path: ./**/TESTS*.xml
           reporter: java-junit
           only-summary: 'true'
+          use-actions-summary: 'true'
           fail-on-error: 'false'
 
       - name: 'create an empty ./dist/ui-components/cdn folder'


### PR DESCRIPTION
This PR fixes the test report creation failure on workflow runs that were triggered by a pull request (rather than triggered by a commit on a branch)

# Problem

When the workflow run is triggered by a commit on a branch, the `GITHUB_TOKEN` that is generated by GitHub Actions to interface with the GitHub API receives more permissions, than when the workflow run is triggered by a pull request (this is by design, to ensure security)

As such, workflow runs that happen on pull requests (like https://github.com/Laserfiche/lf-ui-components/actions/runs/18535678310/job/52906400977) don't receive the necessary permission to create checks in GitHub.

The test reporter (`dorny/test-reporter`) relies heavily on the GitHub API and the token to upload the test results summary. Because of this, all PR workflows fail during the test report creation since the test reporter can't create the check in GitHub.

# Background

The relevant issue in the test reporter repository is: https://github.com/dorny/test-reporter/issues/229

They suggest setting:
```
    permissions:
      checks: write
```

however, this is already set in the `lf-ui-components` CI workflow.

The README suggests [creating two separate workflows](https://github.com/dorny/test-reporter?tab=readme-ov-file#recommended-setup-for-public-repositories), one for creating test report artifacts, and another for creating the test report summary itself:
<img width="980" height="865" alt="image" src="https://github.com/user-attachments/assets/6cf0314b-9e74-42e3-95b1-c7ba5cbeb0a5" />

I've tried this, but it introduces two main issues:
- The workflow, when ran, is a separate workflow, not part of the same workflow - so test reports are no longer available from just glancing at the build workflow itself
- The test report workflow doesn't execute always after the execution of the main workflow - this seems to be a hiccup on GitHub's side but it suggests that this solution is not reliable as GitHub is right now

# Solution

This isn't documented, but when `use-actions-summary` is set to `true`, summaries are generated using the core Actions SDK instead of creating and updating a check entity on the GitHub API.

This means, that by setting `use-actions-summary` to `true`, we can sidestep the entire GitHub API and use GitHub Actions to share the summary table instead. (This is possible because the table is actually saved into the stdout of the test reporting, not uploaded separately to GitHub)

This is fine, because the final status of the workflow (whether it passes or fails) is actually determined by the `npm test` command itself - if there are test results, the workflow's final status will be "failed". So it's not necessary to create a check on GitHub per se to control the workflow status.

This resolves the main issue - no more `HttpError` during test summary creation in workflows triggered by pull requests - this makes it possible to merge pull requests, which is only possible when all checks pass.

And as a nice bonus, test reports are now available directly from the GitHub user interface, no need to search for the check HTML link anymore in the workflow run logs :)

<img width="1665" height="847" alt="image" src="https://github.com/user-attachments/assets/f1705aea-ad06-48a4-88cb-46792c794d93" />