### PR TITLE
Enhance keyboard navigation of adhoc-container

### DIFF
--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.css
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.css
@@ -21,17 +21,12 @@
   margin-bottom: 0;
 }
 
-.back-button-padding {
-  text-align: right;
-  max-height: 43px;
-  border-bottom: 1px solid #ddd;
-  border-top: 1px solid #ddd;
-  box-sizing: border-box;
-  padding: 20px;
-}
 
 .back-button-overlay {
-  position: absolute;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
 }
 
 .back-button:hover {
@@ -43,7 +38,6 @@
   vertical-align: middle;
   font-weight: bold;
   display: inline-block;
-  cursor: pointer;
   font-size: 14px;
 }
 
@@ -77,13 +71,14 @@ i.loader {
 
 .button-padding-container {
   padding: 10px;
+  display: flex;
+  justify-content: end;
 }
 
 .adhoc-back-button-container {
-  height: 42px;
-  display: inline-block;
-  cursor: pointer;
-  vertical-align: middle;
+  height: 40px;
+  border: none;
+  background-color: transparent;
 }
 
 .adhoc-back-button-container:hover {
@@ -91,8 +86,7 @@ i.loader {
 }
 
 .adhoc-back-button {
-  color: #767676;
-  padding: 12px 5px 12px 15px;
+  display: flex;
   font-size: 18px;
   font-weight: bold;
   box-sizing: content-box;
@@ -165,6 +159,10 @@ i.loader {
   flex-grow: 1;
 }
 
+::ng-deep cdk-virtual-scroll-viewport .cdk-virtual-scroll-content-wrapper {
+  padding-bottom: 8px;
+}
+
 .error-entries-text {
   color: #AB2227;
 }
@@ -182,7 +180,7 @@ i.loader {
 
 ::ng-deep .add-remove-container .mat-mdc-checkbox .mdc-checkbox {
   padding-left: 0px;
-  padding-right: 0px;
+  padding-right: 8px;
 }
 
 ::ng-deep .add-remove-container .mat-mdc-checkbox .mdc-checkbox__background {

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.html
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.html
@@ -1,7 +1,7 @@
 <!--Copyright (c) Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<div id="add-remove-container" class="add-remove-container" cdkTrapFocus tabindex="0">
+<div id="add-remove-container" class="add-remove-container" cdkTrapFocus tabindex="0" (keydown.escape)="ignoreEscapeKeydown($event)">
   <div id="adhoc-back-button" class="back-button-overlay">
     <button class="adhoc-back-button-container" (click)="onClickBack()" >
       <span class="material-icons adhoc-back-button" id="arrow-left-18" aria-label="back"> arrow_back_ios_new </span>

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.html
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.html
@@ -1,14 +1,13 @@
 <!--Copyright (c) Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<div id="add-remove-container" class="add-remove-container">
-  <div id="adhoc-back-button" class="back-button-overlay" (click)="onClickBack()">
-    <div class="adhoc-back-button-container">
-      <span class="material-icons lf-button adhoc-back-button" id="arrow-left-18"> arrow_back_ios_new </span>
-    </div>
+<div id="add-remove-container" class="add-remove-container" cdkTrapFocus tabindex="0">
+  <div id="adhoc-back-button" class="back-button-overlay">
+    <button class="adhoc-back-button-container" (click)="onClickBack()" >
+      <span class="material-icons adhoc-back-button" id="arrow-left-18" aria-label="back"> arrow_back_ios_new </span>
+    </button>    
     <div class="ms-font-m back-button-text">{{ ADD_REMOVE_FIELDS | async }}</div>
   </div>
-  <div class="back-button-padding"></div>
   <div class="add-remove-content">
     <ng-container *ngIf="isLoading; else checkIfError">
       <lf-loader-component class="lf-adhoc-state-message"></lf-loader-component>

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.spec.ts
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.spec.ts
@@ -184,7 +184,7 @@ describe('LfFieldAddRemoveComponent', () => {
     // Arrange
     spyOn(component.clickBack, 'emit');
     // Act
-    const backButton = element.querySelector('#adhoc-back-button') as HTMLButtonElement;
+    const backButton = element.querySelector('#adhoc-back-button > button') as HTMLButtonElement;
     backButton.click();
 
     // Assert

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.ts
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-add-remove/lf-field-add-remove.component.ts
@@ -181,6 +181,10 @@ export class LfFieldAddRemoveComponent implements AfterViewInit {
     this.checkboxUpdate.emit();
   }
 
+  ignoreEscapeKeydown(event: KeyboardEvent) {
+    event.stopPropagation();
+  }
+
   private updateSelectedOptions(checked: boolean, field: LfFieldInfo) {
     if (checked) {
       this.selectedFieldIds.add(field.id);

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.html
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.html
@@ -21,8 +21,8 @@ Licensed under the MIT License. See LICENSE in the project root for license info
     <ng-template lfFieldView></ng-template>
   </div>
 </div>
-<div [hidden]="!showAdhocModal" class="addRemoveModal" class="adhoc-modal">
-  <div class="adhoc-modal-content">
+<div [hidden]="!showAdhocModal" class="addRemoveModal" class="adhoc-modal" >
+  <div class="adhoc-modal-content" #adhocPanel tabindex="0">
     <lf-field-add-remove-component (clickBack)="onClickBackAsync()"></lf-field-add-remove-component>
   </div>
 </div>

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.ts
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-import { Component, ChangeDetectorRef, Input, ViewChild, OnDestroy, ComponentRef, AfterViewInit, EventEmitter, Output, NgZone } from '@angular/core';
+import { Component, ChangeDetectorRef, Input, ViewChild, OnDestroy, ComponentRef, AfterViewInit, EventEmitter, Output, NgZone, ElementRef } from '@angular/core';
 import { LfFieldAdhocContainerService as LfFieldAdhocContainerService } from './lf-field-adhoc-container.service';
 import { AdhocFieldConnectorService } from './lf-field-adhoc-connector.service';
 import { AdhocFieldInfo } from './lf-field-adhoc-container-types';
@@ -24,6 +24,7 @@ import { CoreUtils } from '@laserfiche/lf-js-utils';
 export class LfFieldAdhocContainerComponent extends LfFieldContainerDirective implements OnDestroy, AfterViewInit {
   /** @internal */
   @ViewChild(LfFieldAddRemoveComponent) addRemoveComponent!: LfFieldAddRemoveComponent;
+  @ViewChild('adhocPanel') adhocPanel?: ElementRef<HTMLElement>;
   @Output() dialogOpened = new EventEmitter<void>();
   @Output() dialogClosed = new EventEmitter<void>();
 
@@ -244,6 +245,7 @@ export class LfFieldAdhocContainerComponent extends LfFieldContainerDirective im
     this.metadataConnectorService.setAddRemoveContainerToggled(open);
     if (open) {
       this.dialogOpened.emit();
+      setTimeout(() => this.adhocPanel?.nativeElement.focus());
     }
     else {
       this.dialogClosed.emit();

--- a/projects/ui-components/lf-metadata/lf-metadata.module.ts
+++ b/projects/ui-components/lf-metadata/lf-metadata.module.ts
@@ -20,6 +20,7 @@ import { LfFieldViewDirective } from './lf-field-view.directive';
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import { MatDialogModule } from '@angular/material/dialog';
 import { LfUniDateTimeModule } from './lf-date-time-picker/uni-date-time.module';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
   declarations: [
@@ -31,6 +32,7 @@ import { LfUniDateTimeModule } from './lf-date-time-picker/uni-date-time.module'
     LfFieldViewDirective
   ],
   imports: [
+    A11yModule,
     CommonModule,
     BrowserAnimationsModule,
     MatSelectModule,


### PR DESCRIPTION
This PR enhances the keyboard navigation for **Add/remove fields** panel. 

These are the main changes:
- Prevent focus jumping. During keyboard navigation, focus escapes the **Add/remove fields** panel
- Back button in the **Add/remove fields** panel was unreachable via keyboard navigation
- Added more spacing between the checkboxes and their labels
- Added extra spacing for checklist container
- Aligned adhoc-container action buttons to the right for consistency with other components, like _lf-checklist_ component. 
- Block propagation of the Escape event
