### PR TITLE
Enhance keyboard navigation of lf-repository-browser

### DIFF
--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.css
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.css
@@ -14,6 +14,10 @@
   flex: 1 1 auto;
 }
 
+.lf-repo-entry-container:focus {
+  outline: 1px solid #000;
+}
+
 #message-display {
   display: flex;
   flex-direction: column;

--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
@@ -5,7 +5,7 @@ Licensed under the MIT License. See LICENSE in the project root for license info
   <lf-breadcrumbs-component [breadcrumbs]="breadcrumbs" (breadcrumbClicked)="onBreadcrumbClicked($event)">
   </lf-breadcrumbs-component>
 </div>
-<div class="lf-repo-entry-container" [attr.tabindex]="shouldShowEmptyMessage ? 0 : -1">
+<div class="lf-repo-entry-container" [attr.tabindex]="isLoading || shouldShowErrorMessage || shouldShowEmptyMessage ? 0 : -1">
   <lf-loader-component *ngIf="isLoading" class="lf-text-body lf-no-user-select"></lf-loader-component>
   <div id="message-display" *ngIf="!isLoading && (shouldShowErrorMessage || shouldShowEmptyMessage)">
     <div *ngIf="shouldShowErrorMessage" class="lf-text-body lf-text-error lf-no-user-select">{{ AN_ERROR_OCCURED | async }}</div>

--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
@@ -1,11 +1,11 @@
 <!--Copyright (c) Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<div class="lf-repository-browser-header" tabindex="0">
+<div class="lf-repository-browser-header">
   <lf-breadcrumbs-component [breadcrumbs]="breadcrumbs" (breadcrumbClicked)="onBreadcrumbClicked($event)">
   </lf-breadcrumbs-component>
 </div>
-<div class="lf-repo-entry-container">
+<div class="lf-repo-entry-container" [attr.tabindex]="shouldShowEmptyMessage ? 0 : -1">
   <lf-loader-component *ngIf="isLoading" class="lf-text-body lf-no-user-select"></lf-loader-component>
   <div id="message-display" *ngIf="!isLoading && (shouldShowErrorMessage || shouldShowEmptyMessage)">
     <div *ngIf="shouldShowErrorMessage" class="lf-text-body lf-text-error lf-no-user-select">{{ AN_ERROR_OCCURED | async }}</div>

--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
@@ -1,7 +1,7 @@
 <!--Copyright (c) Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<div class="lf-repository-browser-header">
+<div class="lf-repository-browser-header" tabindex="0">
   <lf-breadcrumbs-component [breadcrumbs]="breadcrumbs" (breadcrumbClicked)="onBreadcrumbClicked($event)">
   </lf-breadcrumbs-component>
 </div>

--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.ts
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.ts
@@ -503,10 +503,11 @@ export class LfRepositoryBrowserComponent implements OnDestroy, AfterViewInit {
     if (!entry?.isContainer) {
       return;
     }
+    this._breadcrumbs = [entry].concat(this.breadcrumbs);
     this._currentFolder = entry;
     await this.updateAllPossibleEntriesAsync(entry);
-    this._breadcrumbs = [entry].concat(this.breadcrumbs);
-    this.entryList?.focus();
+    
+    this._focus();
   }
 
   /**
@@ -561,7 +562,13 @@ export class LfRepositoryBrowserComponent implements OnDestroy, AfterViewInit {
       setTimeout(() => this._focus(node, tries + 1));
       return;
     }
-    this.entryList.focus();
+    if (this.shouldShowEmptyMessage || this.shouldShowErrorMessage) {
+      setTimeout(() => {
+        (document.querySelector(".lf-repo-entry-container") as HTMLElement)?.focus();
+      })
+    } else {
+      this.entryList?.focus();
+    }
   }
 
   /**

--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.ts
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.ts
@@ -503,10 +503,9 @@ export class LfRepositoryBrowserComponent implements OnDestroy, AfterViewInit {
     if (!entry?.isContainer) {
       return;
     }
-    this._breadcrumbs = [entry].concat(this.breadcrumbs);
     this._currentFolder = entry;
     await this.updateAllPossibleEntriesAsync(entry);
-    
+    this._breadcrumbs = [entry].concat(this.breadcrumbs);
     this._focus();
   }
 
@@ -565,7 +564,7 @@ export class LfRepositoryBrowserComponent implements OnDestroy, AfterViewInit {
     if (this.shouldShowEmptyMessage || this.shouldShowErrorMessage) {
       setTimeout(() => {
         (document.querySelector(".lf-repo-entry-container") as HTMLElement)?.focus();
-      })
+      });
     } else {
       this.entryList?.focus();
     }

--- a/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.css
+++ b/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.css
@@ -100,13 +100,21 @@
 }
 
 ::ng-deep .breadcrumb-split-button.mat-button-toggle-checked {
-  background-color: inherit;
+  background-color: transparent !important;
 }
 
 ::ng-deep .breadcrumb-split-button.mat-button-toggle-appearance-standard .mat-button-toggle-focus-overlay,
 ::ng-deep .breadcrumb-split-button.mat-button-toggle-appearance-standard,
-::ng-deep .breadcrumb-split-button .mat-button-toggle-button {
+::ng-deep .breadcrumb-split-button .mat-button-toggle-button,
+::ng-deep .breadcrumb-split-button .mat-button-toggle-button button {
   height: 25px;
+  width: 100%;
+}
+
+::ng-deep .breadcrumb-split-button .mat-button-toggle-button button {
+  border: unset;
+  background-color: unset;
+  padding: 0;
 }
 
 ::ng-deep .breadcrumb-split-button.mat-button-toggle-appearance-standard {
@@ -122,6 +130,6 @@
   white-space: nowrap;
 }
 
-::ng-deep .breadcrumb-select.mat-button-toggle-appearance-standard.mat-button-toggle-checked {
-  background-color: transparent;
+::ng-deep .mat-button-toggle-button button {
+  outline: none;
 }

--- a/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.html
+++ b/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.html
@@ -2,18 +2,22 @@
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
 <div class="lf-breadcrumbs-container">
-  <div *ngIf="breadcrumbs?.length > 1" class="breadcrumbs-dropdown-container">
+  <div *ngIf="breadcrumbs?.length > 1" class="breadcrumbs-dropdown-container" hideSingleSelectionIndicator>
       <mat-button-toggle-group class="breadcrumb-split-button-group">
           <mat-button-toggle class="breadcrumb-clickable-parent lf-button primary-button breadcrumb-split-button"
               [ngClass]="{'single-selectable': breadcrumbs.length===2}"
-              (change)="onBreadcrumbSelected(breadcrumbs[1])" [title]="breadcrumbs[1]?.name">
+              (click)="onBreadcrumbSelected(breadcrumbs[1])" (keydown)="onKeydown($event, breadcrumbs[1])" 
+              [title]="breadcrumbs[1]?.name">
               {{breadcrumbs[1]?.name}}
           </mat-button-toggle>
           <mat-button-toggle class="breadcrumb-select breadcrumb-split-button" *ngIf="breadcrumbs?.length > 2"
-              [matMenuTriggerFor]="breadcrumbDropdownMenu">
-              <span class="material-icons breadcrumb-split-button-icon">
-                arrow_drop_down
-              </span>
+              value="breadcrumbDropdownMenu" (change)="onDropdownMenuSelected()" tabindex="-1">
+              <button #dropdownMenuButton mat-icon-button [matMenuTriggerFor]="breadcrumbDropdownMenu"
+                (click)="$event.stopPropagation()" tabindex="0">
+                <span class="material-icons breadcrumb-split-button-icon">
+                  arrow_drop_down
+                </span>
+              </button>
           </mat-button-toggle>
       </mat-button-toggle-group>
 

--- a/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.html
+++ b/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.html
@@ -2,11 +2,13 @@
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
 <div class="lf-breadcrumbs-container">
-  <div *ngIf="breadcrumbs?.length > 1" class="breadcrumbs-dropdown-container" hideSingleSelectionIndicator>
-      <mat-button-toggle-group class="breadcrumb-split-button-group">
+  <div *ngIf="breadcrumbs?.length > 1" class="breadcrumbs-dropdown-container">
+      <mat-button-toggle-group class="breadcrumb-split-button-group" hideSingleSelectionIndicator>
           <mat-button-toggle class="breadcrumb-clickable-parent lf-button primary-button breadcrumb-split-button"
               [ngClass]="{'single-selectable': breadcrumbs.length===2}"
-              (click)="onBreadcrumbSelected(breadcrumbs[1])" (keydown)="onKeydown($event, breadcrumbs[1])" 
+              (click)="onBreadcrumbSelected(breadcrumbs[1])"
+              (keydown.enter)="onBreadcrumbSelected(breadcrumbs[1])"
+              (keydown.space)="onBreadcrumbSelected(breadcrumbs[1])"
               [title]="breadcrumbs[1]?.name">
               {{breadcrumbs[1]?.name}}
           </mat-button-toggle>

--- a/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.ts
+++ b/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.ts
@@ -18,6 +18,7 @@ export class LfBreadcrumbsComponent {
     breadcrumbs: LfBreadcrumb[];
   }>();
 
+  /** @internal */
   @ViewChild('dropdownMenuButton') dropdownMenuButton!: ElementRef<HTMLButtonElement>;
 
   /** @internal */
@@ -40,6 +41,7 @@ export class LfBreadcrumbsComponent {
     this.breadcrumbClicked.emit({breadcrumbs: newBreadcrumbs, selected: node});
   }
 
+  /** @internal */
   onDropdownMenuSelected() {
     setTimeout(() => this.dropdownMenuButton.nativeElement.focus());
   }

--- a/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.ts
+++ b/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { LfBreadcrumb } from './lf-breadcrumbs-types';
 
 @Component({
@@ -17,6 +17,8 @@ export class LfBreadcrumbsComponent {
     selected: LfBreadcrumb;
     breadcrumbs: LfBreadcrumb[];
   }>();
+
+  @ViewChild('dropdownMenuButton') dropdownMenuButton!: ElementRef<HTMLButtonElement>;
 
   /** @internal */
   constructor() { }
@@ -38,4 +40,13 @@ export class LfBreadcrumbsComponent {
     this.breadcrumbClicked.emit({breadcrumbs: newBreadcrumbs, selected: node});
   }
 
+    onKeydown(event: KeyboardEvent, node: LfBreadcrumb) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      this.onBreadcrumbSelected(node);
+    }
+  }
+
+  onDropdownMenuSelected() {
+    setTimeout(() => this.dropdownMenuButton.nativeElement.focus());
+  }
 }

--- a/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.ts
+++ b/projects/ui-components/shared/lf-breadcrumbs/lf-breadcrumbs.component.ts
@@ -40,12 +40,6 @@ export class LfBreadcrumbsComponent {
     this.breadcrumbClicked.emit({breadcrumbs: newBreadcrumbs, selected: node});
   }
 
-    onKeydown(event: KeyboardEvent, node: LfBreadcrumb) {
-    if (event.key === 'Enter' || event.key === ' ') {
-      this.onBreadcrumbSelected(node);
-    }
-  }
-
   onDropdownMenuSelected() {
     setTimeout(() => this.dropdownMenuButton.nativeElement.focus());
   }


### PR DESCRIPTION
This PR enhances the keyboard navigation for repository browser component.

These are the main changes:

- hide the single selection indicator of breadcrumbs buttons
- enhance the keyboard navigation of breadcrumbs component
- retain keyboard focus inside the repository browser when selected folder is empty