### PR TITLE
Fixing form layout breaks when hint or error messages wrap to multiple lines

### DIFF
--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-field/date-field.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-field/date-field.component.css
@@ -13,3 +13,8 @@
     height: 35px;
     width: 35px;
 }
+
+/* Add extra spacing only when no error is shown to keep date field visually consistent with other form fields */
+.extra-space {
+  margin-bottom: 1rem;
+}

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-field/date-field.component.html
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-field/date-field.component.html
@@ -1,7 +1,7 @@
 <!--Copyright (c) Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<span class="token-picker-field-box" *ngIf="!isDynamic else dynamic">
+<span class="token-picker-field-box" *ngIf="!isDynamic else dynamic" [ngClass]="{'extra-space': !getBrokenValidationRule()}">
   <mat-form-field *ngIf="showTokenTextBox" title="{{lf_field_info.displayName}}" appearance="outline"
     class="lf-field lf-date-field">
     <input #tokenTarget matInput [formControl]="lf_field_form_control" title="{{lf_field_form_control.value}}"

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-time-field/date-time-field.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-time-field/date-time-field.component.css
@@ -74,3 +74,8 @@
 ::ng-deep .ngx-mat-timepicker .mat-mdc-form-field .mat-mdc-form-field-subscript-wrapper {
   height: 0px;
 }
+
+/* Add extra spacing only when no error is shown to keep date-time field visually consistent with other form fields */
+.extra-space {
+  margin-bottom: 1rem;
+}

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-time-field/date-time-field.component.html
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/date-time-field/date-time-field.component.html
@@ -1,7 +1,7 @@
 <!--Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<span class="token-picker-field-box" *ngIf="!isDynamic else dynamic">
+<span class="token-picker-field-box" *ngIf="!isDynamic else dynamic" [ngClass]="{'extra-space': !getBrokenValidationRule()}">
   <mat-form-field *ngIf="showTokenTextBox" title="{{lf_field_info.displayName}}" appearance="outline" class="lf-field">
     <input #tokenTarget matInput [formControl]="lf_field_form_control" title="{{lf_field_form_control.value}}"
       (change)="onDateOrTimeTokenValueChanged()">

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
@@ -119,8 +119,6 @@
 ::ng-deep mat-form-field.lf-textarea .mat-mdc-form-field-subscript-wrapper {
   display: flex;
   flex-direction: column;
-  margin-bottom: 0.25rem;
-  font-size: 75%;
 }
 
 ::ng-deep lf-field-template-container-component .lf-template-picker > .mat-mdc-form-field-subscript-wrapper {
@@ -205,7 +203,7 @@
 ::ng-deep mat-form-field > .mat-mdc-form-field-subscript-wrapper > .mat-mdc-form-field-hint-wrapper,
 ::ng-deep mat-form-field > .mat-mdc-form-field-subscript-wrapper > .mat-mdc-form-field-error-wrapper {
   position: unset;
-  padding: 0 1em;
+  padding: 0;
   min-height: 1.25rem;
 }
 
@@ -219,7 +217,8 @@
 
 ::ng-deep .mat-mdc-form-field-hint,
 ::ng-deep .mat-mdc-form-field-error {
-  line-height: 1.125;
+  line-height: 1rem;
+  font-size: var(--mat-form-field-subscript-text-size);
 }
 
 ::ng-deep mat-form-field > .mat-mdc-form-field-subscript-wrapper.mat-mdc-form-field-bottom-align:before {

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
@@ -117,8 +117,12 @@
 
 ::ng-deep mat-form-field.lf-field .mat-mdc-form-field-subscript-wrapper,
 ::ng-deep mat-form-field.lf-textarea .mat-mdc-form-field-subscript-wrapper {
-  position: static;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0.25rem;
+  font-size: 75%;
 }
+
 ::ng-deep lf-field-template-container-component .lf-template-picker > .mat-mdc-form-field-subscript-wrapper {
   height: 0px;
 }
@@ -198,15 +202,28 @@
   display: none;
 }
 
-::ng-deep .mat-mdc-form-field-error-wrapper {
-  position: relative;
-  padding: 0;
+::ng-deep mat-form-field > .mat-mdc-form-field-subscript-wrapper > .mat-mdc-form-field-hint-wrapper,
+::ng-deep mat-form-field > .mat-mdc-form-field-subscript-wrapper > .mat-mdc-form-field-error-wrapper {
+  position: unset;
+  padding: 0 1em;
+  min-height: 1.25rem;
 }
 
-.mat-mdc-form-field-error {
-  transform: translateY(-80%);
-  padding: 0 16px;
-  font-size: var(--mat-form-field-subscript-text-size);
+::ng-deep .mat-mdc-form-field-hint-spacer {
+  flex-basis: 0 !important;
+}
+
+::ng-deep mat-hint {
+  color: #0009;
+}
+
+::ng-deep .mat-mdc-form-field-hint,
+::ng-deep .mat-mdc-form-field-error {
+  line-height: 1.125;
+}
+
+::ng-deep mat-form-field > .mat-mdc-form-field-subscript-wrapper.mat-mdc-form-field-bottom-align:before {
+  height: unset;
 }
 
 ::ng-deep .lf-field .mdc-text-field {

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
@@ -217,6 +217,7 @@
 
 ::ng-deep .mat-mdc-form-field-hint,
 ::ng-deep .mat-mdc-form-field-error {
+  padding: 0 1rem;
   line-height: 1rem;
   font-size: var(--mat-form-field-subscript-text-size);
 }

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/time-field/time-field.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/time-field/time-field.component.css
@@ -1,3 +1,7 @@
 /*Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.*/
 
+/* Add extra spacing only when no error is shown to keep time field visually consistent with other form fields */
+.extra-space {
+  margin-bottom: 1rem;
+}

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/time-field/time-field.component.html
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/time-field/time-field.component.html
@@ -1,8 +1,7 @@
 <!--Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<span class="token-picker-field-box" *ngIf="!isDynamic else dynamic">
-
+<span class="token-picker-field-box" *ngIf="!isDynamic else dynamic" [ngClass]="{'extra-space': !getBrokenValidationRule()}">
   <mat-form-field *ngIf="showTokenTextBox" title="{{lf_field_info.displayName}}" appearance="outline" class="lf-field">
     <input #tokenTarget matInput type="text" [formControl]="lf_field_form_control"
       title="{{lf_field_form_control.value}}" (change)="onTimeValueChangedAsync()">

--- a/projects/ui-components/lf-metadata/lf-date-time-picker/uni-date-time.component.less
+++ b/projects/ui-components/lf-metadata/lf-date-time-picker/uni-date-time.component.less
@@ -217,7 +217,10 @@ div.flatpickr-current-month .flatpickr-monthDropdown-months option.flatpickr-mon
   letter-spacing: normal;
 }
 
-
 ::ng-deep div.flatpickr-current-month .flatpickr-monthDropdown-months:focus {
     background-color: #eee;
+}
+
+::ng-deep mat-form-field.lf-date-field > .mat-mdc-form-field-subscript-wrapper > .mat-mdc-form-field-hint-wrapper{
+    min-height: 0;
 }

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.css
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.css
@@ -30,3 +30,9 @@
   color: #777;
   padding-top: 10px;
 }
+
+.responsive-form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}

--- a/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.html
+++ b/projects/ui-components/lf-metadata/lf-field-adhoc-container/lf-field-adhoc-container.component.html
@@ -18,7 +18,9 @@ Licensed under the MIT License. See LICENSE in the project root for license info
     >
       {{ NO_ADDITIONAL_FIELDS_ASSIGNED | async }}
     </div>
-    <ng-template lfFieldView></ng-template>
+    <div class="responsive-form-container">
+      <ng-template lfFieldView></ng-template>
+    </div>
   </div>
 </div>
 <div [hidden]="!showAdhocModal" class="addRemoveModal" class="adhoc-modal" >

--- a/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.css
+++ b/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.css
@@ -24,3 +24,9 @@
 ::ng-deep lf-field-template-container .lf-template-picker > .mat-mdc-form-field-subscript-wrapper {
   height: 0px;
 } 
+
+.responsive-form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}

--- a/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.html
+++ b/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.html
@@ -37,7 +37,9 @@ Licensed under the MIT License. See LICENSE in the project root for license info
     </ng-container>
     <ng-template #checkIfDisplay>
       <ng-container *ngIf="isTemplateDisplay; else emptyFieldView">
-        <ng-template lfFieldView></ng-template>
+        <div class="responsive-form-container">
+          <ng-template lfFieldView></ng-template>
+        </div>
       </ng-container>
     <ng-template #emptyFieldView></ng-template>
     </ng-template>


### PR DESCRIPTION
This PR includes the following fixes:

- resolves a form layout issue where the long **mat-hint** and **mat-error** messages wrap and visually overlap with other form fields
- it also enhanced the hint message appearance and style, used smaller font size and grayish font color. 
- ensured vertical spacing between form fields and refactored the form layout to be fully responsive.

### Screenshots

#### 1. Hint message overlapping and style

 _**Before**_
> <img width="308" height="182" alt="image" src="https://github.com/user-attachments/assets/594d98a8-da89-4bc3-90ac-0c6b07bde9f9" />

**_After the fix_**
> <img width="321" height="207" alt="image" src="https://github.com/user-attachments/assets/065bacfb-87a6-4f61-9240-ed9980001c56" />
> 

#### 2. Error message alignment
_**Before**_

> <img width="291" height="254" alt="image" src="https://github.com/user-attachments/assets/f2bd71ed-62c9-4578-ae30-0fec040eedb9" />


_**After the fix**_

> <img width="298" height="195" alt="image" src="https://github.com/user-attachments/assets/b67bff4a-2103-41df-b6b0-80ad105281da" />
