### PR TITLE
The lf-repository-browser component can accept lf-toolbar component as its child

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
         working-directory: ./dist/ui-components
 
       - name: Tag commit
-        uses: rickstaa/action-create-tag@v2
+        uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ env.NpmPackageVersion }}
           commit_sha: ${{ github.sha }}
@@ -239,7 +239,7 @@ jobs:
         working-directory: ./dist/ui-components
 
       - name: Tag commit
-        uses: rickstaa/action-create-tag@v2
+        uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ env.NPM_VERSION }}
           commit_sha: ${{ github.sha }}

--- a/projects/lf-documentation/src/app/lf-repository-browser-documentation/lf-repository-browser-documentation.component.html
+++ b/projects/lf-documentation/src/app/lf-repository-browser-documentation/lf-repository-browser-documentation.component.html
@@ -10,6 +10,13 @@ Licensed under the MIT License. See LICENSE in the project root for license info
   </code>
 </p>
 <p class="documentation-text code-container">
+  <label>Web Element with LfToolbar</label>
+  <br />
+  <code>
+    <span class="code-html-tagname">&lt;lf-repository-browser&gt;&lt;lf-toolbar&gt;&lt;/lf-toolbar&gt;&lt;/lf-repository-browser&gt;</span>
+  </code>
+</p>
+<p class="documentation-text code-container">
   <label>Angular Component</label>
   <br />
   <code>
@@ -60,7 +67,7 @@ Licensed under the MIT License. See LICENSE in the project root for license info
     (entryFocused)="onEntryFocused($event)"
     style="height: 500px"
     #singleSelectRepoBrowser
-  ></lf-repository-browser>
+  ><lf-toolbar [dropdown_options]="elementToolbarOptions"></lf-toolbar></lf-repository-browser>
 </app-card>
 
 <label>

--- a/projects/lf-documentation/src/app/lf-repository-browser-documentation/lf-repository-browser-documentation.component.ts
+++ b/projects/lf-documentation/src/app/lf-repository-browser-documentation/lf-repository-browser-documentation.component.ts
@@ -8,6 +8,8 @@ import {
   LfRepositoryBrowserComponent,
 } from './../../../../ui-components/lf-repository-browser/lf-repository-browser-public-api';
 import { DemoRepoService, propIdCreateDate, propIdNameCol, propIdNumberCol } from './demo-repo-service';
+import { ToolbarOption } from './../../../../ui-components/shared/lf-toolbar/lf-toolbar-public-api';
+import { IconUtils } from '@laserfiche/lf-js-utils';
 
 
 
@@ -27,6 +29,15 @@ export class LfRepositoryBrowserDocumentationComponent implements AfterViewInit 
   dataService: DemoRepoService = new DemoRepoService();
   selectable = this._selectable.bind(this);
   singleSelectDataService: DemoRepoService = new DemoRepoService();
+
+  elementToolbarOptions: ToolbarOption[] = [
+    { name: 'Refresh', disabled: false, icon: IconUtils.getDocumentIconUrlFromIconId('document-20') },
+    { name: 'New Folder', disabled: true, icon: IconUtils.getDocumentIconUrlFromIconId('document-20') },
+    { name: 'Download', disabled: true, icon: IconUtils.getDocumentIconUrlFromIconId('document-20') },
+    { name: 'Scan', disabled: true, icon: IconUtils.getDocumentIconUrlFromIconId('document-20') },
+    { name: 'Rename', disabled: false, icon: IconUtils.getDocumentIconUrlFromIconId('document-20') },
+    { name: 'Share', disabled: false, icon: IconUtils.getDocumentIconUrlFromIconId('document-20') },
+  ]; 
 
   elementSelectedEntry: LfTreeNode[] | undefined;
 

--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
@@ -4,6 +4,7 @@ Licensed under the MIT License. See LICENSE in the project root for license info
 <div class="lf-repository-browser-header">
   <lf-breadcrumbs-component [breadcrumbs]="breadcrumbs" (breadcrumbClicked)="onBreadcrumbClicked($event)">
   </lf-breadcrumbs-component>
+  <ng-content select="lf-toolbar"></ng-content>
 </div>
 <div class="lf-repo-entry-container" [attr.tabindex]="isLoading || shouldShowErrorMessage || shouldShowEmptyMessage ? 0 : -1">
   <lf-loader-component *ngIf="isLoading" class="lf-text-body lf-no-user-select"></lf-loader-component>


### PR DESCRIPTION
This PR introduces support for projecting a `lf-toolbar` component into the `lf-repository-browser` component.

- the `lf-repository-browser` can now accept only `lf-toolbar` as its child. It will display in `lf-repository-browser-header` section, right after the `lf-breadcrumbs` component
- any other child components provided will be ignored and not projected
- this change could fix tab-order issue, when `lf-repository-browser` and `lf-toolbar` components were in used in the same container