### PR TITLE
Positioning the error message correctly within the checklist item

### DIFF
--- a/projects/ui-components/lf-checklist/items/items.component.css
+++ b/projects/ui-components/lf-checklist/items/items.component.css
@@ -1,6 +1,5 @@
 .lf-checklist-item {
   display: flex;
-  align-items: center;
   width: 100%;
 }
 
@@ -29,7 +28,6 @@
 
 .lf-checklist-field {
   width: 100%;
-  height: 34px;
 }
 
 .mat-mdc-input-element {
@@ -84,7 +82,6 @@
 }
 
 ::ng-deep .lf-checklist-item .mat-mdc-form-field-subscript-wrapper {
-  position: static;
   margin-top: 0px;
 }
 

--- a/projects/ui-components/lf-checklist/items/items.component.ts
+++ b/projects/ui-components/lf-checklist/items/items.component.ts
@@ -89,6 +89,7 @@ export class ItemsComponent implements OnInit {
 
   private triggerValidation(field: FormControl) {
     field.markAsDirty();
+    field.markAllAsTouched();
     field.updateValueAndValidity();
   }
 

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
@@ -224,6 +224,11 @@
 
 ::ng-deep mat-form-field > .mat-mdc-form-field-subscript-wrapper.mat-mdc-form-field-bottom-align:before {
   height: unset;
+  display: block;
+}
+
+::ng-deep .lf-checklist-item .mat-form-field-invalid .mat-mdc-form-field-subscript-wrapper {
+  padding-top: 0px !important;
 }
 
 ::ng-deep .lf-field .mdc-text-field {


### PR DESCRIPTION
This PR fixes the positioning of the error message in the checklist item and enhances the `triggerValidation` function to display it immediately.