### PR TITLE
Re-initialize the login state when the user cancels the login flow

### DIFF
--- a/projects/lf-documentation/src/app/lf-login-documentation/lf-login-documentation.component.html
+++ b/projects/lf-documentation/src/app/lf-login-documentation/lf-login-documentation.component.html
@@ -359,7 +359,7 @@ sign_out_text.
   <li>Menu</li>
 </ul>
 
-<p class="documentation-sub-header">LoginType type</p>
+<p class="documentation-sub-header">LoginType Enum</p>
 <ul>
   <li>Cloud - default</li>
   <li>Self-Hosted</li>

--- a/projects/ui-components/lf-login/lf-login.component.spec.ts
+++ b/projects/ui-components/lf-login/lf-login.component.spec.ts
@@ -6,6 +6,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { LfLoginComponent } from './lf-login.component';
 import { LoginState } from '@laserfiche/lf-ui-components/shared';
 import { LfLoginService } from './login-utils/lf-login.service';
+import { AccountEndpoints } from 'types-lf-ui-components-publish';
 
 describe('LfLoginComponent', () => {
   let loginService: LfLoginService;
@@ -76,23 +77,31 @@ describe('LfLoginComponent', () => {
     );
   });
 
-  it('getFullLogoutUrl returns logout url', () => {
-    loginService._accountEndpoints = {
-      wsignoutUrl: 'https://accounts.laserfiche.com/WebSTS/?wa=wsignout1.0',
-      webClientUrl: '',
-      regionalDomain: '',
-      oauthAuthorizeUrl: '',
-    };
-    component.redirect_uri = 'test-url';
-    const logoutUrl = component.getFullLogoutUrl();
+  describe('getFullLogoutUrl', () => {
+    it('should return a logout URL when wsignoutUrl is available', () => {
+      const accountEndpoints: AccountEndpoints | undefined = {
+        wsignoutUrl: 'https://accounts.laserfiche.com/WebSTS/?wa=wsignout1.0',
+        webClientUrl: '',
+        regionalDomain: '',
+        oauthAuthorizeUrl: '',
+      };
+      const originalGetAccountEndpointsSpy = spyOn<any>(loginService, 'getAccountEndpoints');
+      originalGetAccountEndpointsSpy.and.returnValue(accountEndpoints);
 
-    expect(logoutUrl).toEqual('https://accounts.laserfiche.com/WebSTS/?wa=wsignout1.0&wreply=test-url');
+      component.redirect_uri = 'test-url';
+      const logoutUrl = component.getFullLogoutUrl();
+
+      expect(logoutUrl).toEqual('https://accounts.laserfiche.com/WebSTS/?wa=wsignout1.0&wreply=test-url');
+    });
+
+    it('should return undefined when wsignoutUrl is unavailable', () => {
+      const originalGetAccountEndpointsSpy = spyOn<any>(loginService, 'getAccountEndpoints');
+      originalGetAccountEndpointsSpy.and.returnValue(undefined);
+
+      expect(component.getFullLogoutUrl()).toBeUndefined();
+    });
   });
 
-  it('getFullLogoutUrl when no signout url available', () => {
-    loginService._accountEndpoints = undefined;
-    expect(component.getFullLogoutUrl()).toBeUndefined();
-  });
 
   it('concatStrings should return second string when no first string', () => {
     expect(component.concatStrings(undefined, 'test')).toEqual('test');

--- a/projects/ui-components/lf-login/lf-login.component.ts
+++ b/projects/ui-components/lf-login/lf-login.component.ts
@@ -21,9 +21,8 @@ import {
   AuthorizationCredentials,
   LfBeforeFetchResult,
   LfHttpRequestHandler,
-  LoginType,
 } from './login-utils/lf-login-types';
-import { LoginMode, LoginState, RedirectBehavior } from '@laserfiche/lf-ui-components/shared';
+import { LoginMode, LoginState, LoginType, RedirectBehavior } from '@laserfiche/lf-ui-components/shared';
 import { AppLocalizationService } from '@laserfiche/lf-ui-components/internal-shared';
 import { LfLoginService } from './login-utils/lf-login.service';
 import { ApiException, PKCEUtils } from '@laserfiche/lf-api-client-core';
@@ -408,7 +407,7 @@ export class LfLoginComponent implements OnDestroy, OnInit, OnChanges, AfterView
         currentLoginType?.previousValue !== currentLoginType?.currentValue)
     ) {
       this.loginService.loginProvider =
-        currentLoginType.currentValue === 'Self-Hosted'
+        currentLoginType.currentValue === LoginType.SelfHosted
           ? new SelfHostedLoginProvider(this.loginService, currentLoginIdentifier.currentValue)
           : new CloudLoginProvider(this.loginService);
     }

--- a/projects/ui-components/lf-login/lf-login.component.ts
+++ b/projects/ui-components/lf-login/lf-login.component.ts
@@ -11,6 +11,7 @@ import {
   OnInit,
   OnChanges,
   SimpleChanges,
+  AfterViewInit,
 } from '@angular/core';
 import { Observable, of, Subscription } from 'rxjs';
 import { AccountInfo, RedirectUriQueryParams } from './login-utils/lf-login-internal-types';
@@ -36,7 +37,7 @@ const CODE_CHALLENGE_METHOD = 'S256';
   templateUrl: './lf-login.component.html',
   styleUrls: ['./lf-login.component.css'],
 })
-export class LfLoginComponent implements OnDestroy, OnInit, OnChanges {
+export class LfLoginComponent implements OnDestroy, OnInit, OnChanges, AfterViewInit {
   @Input() mode: LoginMode = LoginMode.Button;
 
   /**
@@ -85,7 +86,7 @@ export class LfLoginComponent implements OnDestroy, OnInit, OnChanges {
   @Input() set client_id(val: string) {
     this.loginService.client_id = val;
   }
-  get client_id(): string | undefined{
+  get client_id(): string | undefined {
     return this.loginService.client_id;
   }
 
@@ -375,6 +376,15 @@ export class LfLoginComponent implements OnDestroy, OnInit, OnChanges {
     });
   }
 
+  async ngAfterViewInit() {
+    const accessToken = this.authorization_credentials?.accessToken;
+    if (accessToken) {
+      this._state = LoginState.LoggedIn;
+    } else {
+      await this.initializeLoginAsync();
+    }
+  }
+
   /** @internal */
   async ngOnChanges(changes: SimpleChanges) {
     // initialize the login state according to the access token
@@ -389,6 +399,18 @@ export class LfLoginComponent implements OnDestroy, OnInit, OnChanges {
       } else {
         await this.initializeLoginAsync();
       }
+    }
+
+    const currentLoginType = changes['login_type'];
+    if (
+      !this.loginService.loginProvider &&
+      ((currentLoginType?.currentValue && currentLoginType?.isFirstChange()) ||
+        currentLoginType?.previousValue !== currentLoginType?.currentValue)
+    ) {
+      this.loginService.loginProvider =
+        currentLoginType.currentValue === 'Self-Hosted'
+          ? new SelfHostedLoginProvider(this.loginService, currentLoginIdentifier.currentValue)
+          : new CloudLoginProvider(this.loginService);
     }
   }
 
@@ -640,8 +662,8 @@ export class LfLoginComponent implements OnDestroy, OnInit, OnChanges {
 
   /** @internal */
   getFullLogoutUrl(): string | undefined {
-    if (this.loginService._accountEndpoints?.wsignoutUrl) {
-      const acsToLfLogout = new URL(this.loginService._accountEndpoints?.wsignoutUrl);
+    if (this.account_endpoints?.wsignoutUrl) {
+      const acsToLfLogout = new URL(this.account_endpoints?.wsignoutUrl);
       // Warning: if we are already logged out this will behave strangely
       // won't redirect back to redirect Url
       acsToLfLogout.searchParams.set('wreply', this.redirect_uri);

--- a/projects/ui-components/lf-login/login-utils/lf-login-types.ts
+++ b/projects/ui-components/lf-login/login-utils/lf-login-types.ts
@@ -48,5 +48,3 @@ export interface LfHttpRequestHandler {
    */
   afterFetchResponseAsync: (url: string, response: Response, request: RequestInit) => Promise<boolean>;
 }
-
-export type LoginType = 'Cloud' | 'Self-Hosted';

--- a/projects/ui-components/lf-login/login-utils/lf-login.service.ts
+++ b/projects/ui-components/lf-login/login-utils/lf-login.service.ts
@@ -3,8 +3,8 @@
 
 import { EventEmitter, Injectable, Output } from '@angular/core';
 import { AccountInfo, RedirectUriQueryParams } from './lf-login-internal-types';
-import { AbortedLoginError, AuthorizationCredentials, AccountEndpoints, LoginType } from './lf-login-types';
-import { LoginState, RedirectBehavior } from '@laserfiche/lf-ui-components/shared';
+import { AbortedLoginError, AuthorizationCredentials, AccountEndpoints } from './lf-login-types';
+import { LoginState, RedirectBehavior, LoginType } from '@laserfiche/lf-ui-components/shared';
 import { GetAccessTokenResponse, ApiException, JwtUtils } from '@laserfiche/lf-api-client-core';
 import { LoginProvider } from './login-provider';
 const CONTENT_TYPE_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded';
@@ -40,7 +40,7 @@ export class LfLoginService {
   /** @internal */
   code_verifier?: string;
   /** @internal */
-  login_type: LoginType = 'Cloud';
+  login_type: LoginType = LoginType.Cloud;
   /** @internal */
   loginProvider?: LoginProvider;
   /** @internal */

--- a/projects/ui-components/shared/enums.ts
+++ b/projects/ui-components/shared/enums.ts
@@ -46,3 +46,8 @@ export enum LoginMode {
   'Button' = 'Button',
   'Menu' = 'Menu'
 }
+
+export enum LoginType {
+  Cloud = 'Cloud',
+  SelfHosted = 'Self-Hosted'
+}


### PR DESCRIPTION
This PR solves two issues:

- Re-initialize the login state when the user cancels/closes the login popup window
- The login provider did not provide the logout URL correctly