### PR TITLE
Fixing checklist component styles

### DIFF
--- a/projects/styles/lf-laserfiche-lite/sass/_textfield-lf.scss
+++ b/projects/styles/lf-laserfiche-lite/sass/_textfield-lf.scss
@@ -8,7 +8,7 @@ $disabled-border-color: #F3F3F3;
 $border-radius: 2px;
 
 $padding-stack: 7px 10px 8px 10px;
-$margin-stack: 5px 0px;
+$margin-stack: 0px 0px;
 
 $background-color: white;
 $disabled-background-color: #F3F3F3;

--- a/projects/styles/lf-laserfiche-lite/sass/rwc-checklist-lf.scss
+++ b/projects/styles/lf-laserfiche-lite/sass/rwc-checklist-lf.scss
@@ -33,13 +33,12 @@ lf-checklist .mat-form-field-appearance-outline.mat-focused .mat-form-field-outl
   margin-top: 14px;
 }
 
-.lf-checklist-item .fixed-size-icon-container {
-  margin-top: 7px;
+.lf-checklist-item .mat-mdc-checkbox {
+  margin-top: -3px;
 }
 
 .lf-checklist-item .lf-text-field {
   border: none;
-  margin-top: 5px;
   padding: 0px;
 }
 

--- a/projects/styles/lf-ms-office/sass/rwc-checklist-mo.scss
+++ b/projects/styles/lf-ms-office/sass/rwc-checklist-mo.scss
@@ -33,6 +33,10 @@ lf-checklist .mat-form-field-appearance-outline.mat-focused .mat-form-field-outl
   margin-top: 5px;
 }
 
+.lf-checklist-item .mat-mdc-checkbox {
+  margin-top: -3px;
+}
+
 .lf-checklist-item .lf-text-field {
   padding: 0px;
   border: none;

--- a/projects/ui-components/lf-checklist/items/items.component.css
+++ b/projects/ui-components/lf-checklist/items/items.component.css
@@ -12,7 +12,7 @@
   display: flex;
   min-width: 30px;
   width: 30px;
-  height: 30px;
+  height: 34px;
   align-items: center;
   margin-right: 5px;
   position: relative;
@@ -70,6 +70,14 @@
 .mat-mdc-form-field-flex >
 .mat-mdc-form-field-infix input{
   font-size: 14px;
+}
+
+::ng-deep mat-form-field.lf-checklist-field >
+.mat-mdc-text-field-wrapper >
+.mat-mdc-form-field-flex >
+.mat-mdc-form-field-infix {
+  min-height: 28px !important;
+  padding: 4px 0;
 }
 
 ::ng-deep .lf-checklist-item .mat-form-field-appearance-fill .mat-mdc-form-field-flex {


### PR DESCRIPTION
This PR fixes the lf-checklist component styles.

1.  **Laserfiche Theme**: (left side: the fixed version - right side: developer.laserfiche.com)

<img width="1973" height="865" alt="image" src="https://github.com/user-attachments/assets/fa0b042f-1f20-4e87-ae18-bf4b43f3039b" />

2. **Microsoft Theme**

<img width="1973" height="865" alt="image" src="https://github.com/user-attachments/assets/d4a48587-8198-47aa-8c53-49c90700d2ae" />

