### PR TITLE
Refresh token did not work in self-hosted respository

### DIFF
--- a/projects/ui-components/lf-login/login-utils/self-hosted-login-provider.spec.ts
+++ b/projects/ui-components/lf-login/login-utils/self-hosted-login-provider.spec.ts
@@ -35,7 +35,6 @@ describe('SelfHostedLoginProvider', () => {
       extractErrorFromUrl: vi.fn(),
       getAccountEndpoints: vi.fn(),
       accessTokenStorageKey: 'mock-storage-key',
-      getAccountEndpoints: vi.fn(),
     };
 
     provider = new SelfHostedLoginProvider(lfLoginServiceMock as LfLoginService, 'mock-repository-id');
@@ -58,7 +57,7 @@ describe('SelfHostedLoginProvider', () => {
 
   describe('getBaseAuthorizeUrl', () => {
     it('should return the base authorize URL when last OAuth authorize URL exist and host name does not include dev and test environments', () => {
-      lfLoginServiceMock.self_hosted_account_endpoints = accountEndpointsMock;
+      lfLoginServiceMock.getAccountEndpoints = vi.fn().mockReturnValue(accountEndpointsMock);
       const baseAuthorizeUrl = provider.getBaseAuthorizeUrl();
       expect(baseAuthorizeUrl).toBe(accountEndpointsMock.oauthAuthorizeUrl);
     });

--- a/projects/ui-components/lf-login/login-utils/self-hosted-login-provider.ts
+++ b/projects/ui-components/lf-login/login-utils/self-hosted-login-provider.ts
@@ -23,7 +23,11 @@ export class SelfHostedLoginProvider implements LoginProvider {
   }
 
   getBaseAuthorizeUrl(): string {
-    return this.lfLoginService.self_hosted_account_endpoints?.oauthAuthorizeUrl ?? '';
+    return (
+      this.lfLoginService.self_hosted_account_endpoints?.oauthAuthorizeUrl ??
+      this.lfLoginService.getAccountEndpoints()?.oauthAuthorizeUrl ??
+      ''
+    );
   }
 
   storeInLocalStorage(accessTokenCredentials: AuthorizationCredentials, _accountId: string, _regionalDomain: string) {


### PR DESCRIPTION
Refresh token did not work in self-hosted repository due to a wrong base URL. 