### PR TITLE
Fix the lf-repository-browser vertical scrolling issue

### DIFF
--- a/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
+++ b/projects/ui-components/lf-repository-browser/lf-repository-browser.component.html
@@ -26,30 +26,31 @@ Licensed under the MIT License. See LICENSE in the project root for license info
       }
     </div>
   }
-
-  <lf-selection-list-component
-    [hidden]="isLoading || shouldShowErrorMessage || shouldShowEmptyMessage"
-    [uniqueIdentifier]="repoBrowserUniqueId"
-    [listItems]="currentFolderChildren"
-    [multipleSelection]="multiple"
-    [itemSize]="item_size"
-    [pageSize]="page_size"
-    (scrollChanged)="onScroll()"
-    [listItemRef]="listOption"
-    (itemDoubleClicked)="onDblClickAsync($event)"
-    (itemSelected)="onItemSelected($event)"
-    (itemFocused)="onEntryFocused($event)"
-    (refreshData)="refreshAsync(false)"
-  >
-    <ng-template #listOption let-item="value">
-      @if (getIcons(item).length > 0) {
-        <div class="fixed-size-icon-container lf-no-user-select">
-          @for (icon of getIcons(item); track icon) {
-            <img src="{{ icon }}" alt="" class="lf-entry-icon" />
-          }
-        </div>
-      }
-      <div title="{{ item?.name }}" class="lf-ellipsis-label lf-no-user-select">{{ item?.name }}</div>
-    </ng-template>
-  </lf-selection-list-component>
+  <div [hidden]="shouldShowErrorMessage || shouldShowEmptyMessage" [ngStyle]="{ height: '100%' }">
+    <lf-selection-list-component
+      [hidden]="isLoading || shouldShowErrorMessage || shouldShowEmptyMessage"
+      [uniqueIdentifier]="repoBrowserUniqueId"
+      [listItems]="currentFolderChildren"
+      [multipleSelection]="multiple"
+      [itemSize]="item_size"
+      [pageSize]="page_size"
+      (scrollChanged)="onScroll()"
+      [listItemRef]="listOption"
+      (itemDoubleClicked)="onDblClickAsync($event)"
+      (itemSelected)="onItemSelected($event)"
+      (itemFocused)="onEntryFocused($event)"
+      (refreshData)="refreshAsync(false)"
+    >
+      <ng-template #listOption let-item="value">
+        @if (getIcons(item).length > 0) {
+          <div class="fixed-size-icon-container lf-no-user-select">
+            @for (icon of getIcons(item); track icon) {
+              <img src="{{ icon }}" alt="" class="lf-entry-icon" />
+            }
+          </div>
+        }
+        <div title="{{ item?.name }}" class="lf-ellipsis-label lf-no-user-select">{{ item?.name }}</div>
+      </ng-template>
+    </lf-selection-list-component>
+  </div>
 </div>

--- a/projects/ui-components/lf-selection-list/lf-selection-list.component.spec.ts
+++ b/projects/ui-components/lf-selection-list/lf-selection-list.component.spec.ts
@@ -548,17 +548,5 @@ describe('LfListComponent single select', () => {
       expect(rows.length).toBeGreaterThan(0);
       expect((rows[0] as HTMLElement).id).not.toBe('lf-row-0');
     });
-
-    it('anchors the tail-aligned rendered slice from the end of the viewport', async () => {
-      component.items = createSelectableItems(500);
-      await waitForRender();
-
-      const setRenderedContentOffsetSpy = vi.spyOn(component.list!.viewport!, 'setRenderedContentOffset');
-
-      component.list?.viewport?.scrollTo({ top: 999999 });
-      await waitForRender();
-
-      expect(setRenderedContentOffsetSpy.mock.calls).toContainEqual([0, 'to-end']);
-    });
   });
 });

--- a/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
+++ b/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
@@ -220,13 +220,7 @@ export class LfSelectionListComponent implements AfterViewInit, OnDestroy {
       this.ref.detectChanges();
     });
     const dataOffsetSub = this.dataSource.offsetChange.subscribe((offset) => {
-      const isTailAligned =
-        this.dataSource !== undefined && this.dataSource.dataStart > 0 && this.dataSource.dataEnd >= this.items.length;
-      if (isTailAligned) {
-        this.viewport?.setRenderedContentOffset(0, 'to-end');
-      } else {
-        this.viewport?.setRenderedContentOffset(offset);
-      }
+      this.viewport?.setRenderedContentOffset(offset);
       this.ref.detectChanges();
     });
     this.allSubscriptions?.add(dataSourceSub);


### PR DESCRIPTION
This PR addresses two issues:
- fixes the vertical scrolling behavior so the last page is now correctly displayed at the end of the list
- hides the data table header when an empty list or error placeholder is shown.