### PR TITLE
Fix redundant API calls and missing loader in LfFieldTemplateContainerComponent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  NPM_VERSION: "21.1.0"
+  NPM_VERSION: "21.1.1"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <!--Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
+
 ## 21.1.1
 
 ### Fixes
@@ -11,7 +12,6 @@ Licensed under the MIT License. See LICENSE in the project root for license info
 
 - Exposed `LfTagsService` interface.
 - **[BREAKING]**: `lf-tags` emits full tag objects (ITagDefinition[]) instead of tag names (string[]) via selectedTagsChanged.
-
 
 ## 21.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 <!--Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
+## 21.1.1
+
+### Fixes
+
+- `[lf-field-template-container]`: Fixed `getDynamicFieldValueOptionsAsync` being called once per base dynamic field on template load, causing N redundant network requests. The call is now made once and the result shared across all fields.
+- `[lf-field-template-container]`: Fixed the loading indicator disappearing before all async work completed when loading a template with dynamic fields.
 
 ## 21.1.0
 
 - Exposed `LfTagsService` interface.
 - **[BREAKING]**: `lf-tags` emits full tag objects (ITagDefinition[]) instead of tag names (string[]) via selectedTagsChanged.
+
 
 ## 21.0.1
 

--- a/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
+++ b/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
@@ -391,43 +391,49 @@ export class LfFieldTemplateContainerComponent extends LfFieldContainerDirective
   private async updateTemplateFieldInfoAsync(): Promise<void> {
     await this.updateAllFieldInfosFromServiceAsync();
 
-    const hasBaseDynamicField = this.allFieldInfos.some(
-      (fieldInfo) => isDynamicField(fieldInfo) && (fieldInfo as TemplateFieldInfo).rule?.ancestors.length === 0
+    const baseDynamicFields = this.allFieldInfos.filter(
+      (fieldInfo): fieldInfo is TemplateFieldInfo =>
+        isDynamicField(fieldInfo) && (fieldInfo as TemplateFieldInfo).rule?.ancestors.length === 0
     );
-
-    let dynamicFieldValueOptions: { [fieldId: number]: string[] } = {};
-    if (hasBaseDynamicField) {
-      try {
-        dynamicFieldValueOptions = await this.getDynamicFieldValueOptionsAsync(0);
-      } catch (err: unknown) {
-        this.templateState = TemplateState.HAS_ERROR;
-        this.templateErrorMessage = this.TEMPLATE_HAS_FAILED_TO_LOAD;
-        let consoleErrMsg: string = 'getDynamicFieldValueOptionsAsync failed';
-        if (err instanceof Error) {
-          consoleErrMsg = consoleErrMsg + ': ' + err.message;
-        }
-        console.error(consoleErrMsg);
-        throw err;
-      }
+    const noDynamicFieldsToInitialize = baseDynamicFields.length === 0;
+    if (noDynamicFieldsToInitialize) {
+      return;
     }
 
-    for (const fieldInfo of this.allFieldInfos) {
-      const fieldInfoAsTemplateFieldInfo: TemplateFieldInfo = fieldInfo as TemplateFieldInfo;
-      const dynamicOptions = this.getOrCreateDynamicOptions(fieldInfo);
-      const isBaseDynamicField = isDynamicField(fieldInfo) && fieldInfoAsTemplateFieldInfo.rule?.ancestors.length === 0;
-      if (isBaseDynamicField) {
-        const fieldValue = this.getOrCreateFieldValue(fieldInfo.id);
-        const numValues = fieldValue.values?.length ?? 1;
-        for (let index = 0; index < numValues; index++) {
-          dynamicOptions[index] = dynamicFieldValueOptions[fieldInfo.id];
-          if (dynamicOptions[index] === undefined) {
-            console.warn(`Could not get dynamic field options of field ${fieldInfo.name} id ${fieldInfo.id}`);
-            continue;
-          }
-          const values: string[] = this.getValueIfSingleOption(dynamicOptions[index]);
-          await this.updateDynamicFieldsAsync(fieldInfo, values, index);
-        }
+    let dynamicFieldValueOptions: { [fieldId: number]: string[] } = {};
+    try {
+      dynamicFieldValueOptions = await this.getDynamicFieldValueOptionsAsync(0);
+    } catch (err: unknown) {
+      this.templateState = TemplateState.HAS_ERROR;
+      this.templateErrorMessage = this.TEMPLATE_HAS_FAILED_TO_LOAD;
+      let consoleErrMsg = 'getDynamicFieldValueOptionsAsync failed';
+      if (err instanceof Error) {
+        consoleErrMsg += ': ' + err.message;
       }
+      console.error(consoleErrMsg);
+      throw err;
+    }
+
+    for (const fieldInfo of baseDynamicFields) {
+      await this.initBaseDynamicFieldAsync(fieldInfo, dynamicFieldValueOptions);
+    }
+  }
+
+  /** @internal */
+  private async initBaseDynamicFieldAsync(
+    fieldInfo: TemplateFieldInfo,
+    dynamicFieldValueOptions: { [fieldId: number]: string[] }
+  ): Promise<void> {
+    const dynamicOptions = this.getOrCreateDynamicOptions(fieldInfo);
+    const numValues = this.getOrCreateFieldValue(fieldInfo.id).values?.length ?? 1;
+    for (let index = 0; index < numValues; index++) {
+      dynamicOptions[index] = dynamicFieldValueOptions[fieldInfo.id];
+      if (dynamicOptions[index] === undefined) {
+        console.warn(`Could not get dynamic field options of field ${fieldInfo.name} id ${fieldInfo.id}`);
+        continue;
+      }
+      const values: string[] = this.getValueIfSingleOption(dynamicOptions[index]);
+      await this.updateDynamicFieldsAsync(fieldInfo, values, index);
     }
   }
 

--- a/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
+++ b/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
@@ -380,6 +380,10 @@ export class LfFieldTemplateContainerComponent extends LfFieldContainerDirective
     this.allFieldValues = this.metadataFieldConnectorService.getAllFieldValues() ?? {};
     const newFieldIds: number[] = this.allFieldInfos.map((fieldInfo) => fieldInfo.id);
     this.metadataFieldConnectorService.selectTemplateFields(newFieldIds);
+    const noErrorOccurred = this.templateState === TemplateState.LOADING;
+    if (noErrorOccurred) {
+      this.templateState = TemplateState.SHOW_TEMPLATE;
+    }
     await this.renderFieldsAsync(this.allFieldInfos);
   }
 
@@ -450,7 +454,6 @@ export class LfFieldTemplateContainerComponent extends LfFieldContainerDirective
           }
           return validFieldType;
         });
-        this.templateState = TemplateState.SHOW_TEMPLATE;
       } catch (err: unknown) {
         this.templateErrorMessage = this.TEMPLATE_HAS_FAILED_TO_LOAD;
         var consoleErrMsg = 'getTemplateFieldsAsync failed';

--- a/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
+++ b/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
@@ -387,33 +387,41 @@ export class LfFieldTemplateContainerComponent extends LfFieldContainerDirective
   private async updateTemplateFieldInfoAsync(): Promise<void> {
     await this.updateAllFieldInfosFromServiceAsync();
 
+    const hasBaseDynamicField = this.allFieldInfos.some(
+      (fieldInfo) => isDynamicField(fieldInfo) && (fieldInfo as TemplateFieldInfo).rule?.ancestors.length === 0
+    );
+
+    let dynamicFieldValueOptions: { [fieldId: number]: string[] } = {};
+    if (hasBaseDynamicField) {
+      try {
+        dynamicFieldValueOptions = await this.getDynamicFieldValueOptionsAsync(0);
+      } catch (err: unknown) {
+        this.templateState = TemplateState.HAS_ERROR;
+        this.templateErrorMessage = this.TEMPLATE_HAS_FAILED_TO_LOAD;
+        let consoleErrMsg: string = 'getDynamicFieldValueOptionsAsync failed';
+        if (err instanceof Error) {
+          consoleErrMsg = consoleErrMsg + ': ' + err.message;
+        }
+        console.error(consoleErrMsg);
+        throw err;
+      }
+    }
+
     for (const fieldInfo of this.allFieldInfos) {
       const fieldInfoAsTemplateFieldInfo: TemplateFieldInfo = fieldInfo as TemplateFieldInfo;
       const dynamicOptions = this.getOrCreateDynamicOptions(fieldInfo);
       const isBaseDynamicField = isDynamicField(fieldInfo) && fieldInfoAsTemplateFieldInfo.rule?.ancestors.length === 0;
       if (isBaseDynamicField) {
-        try {
-          const fieldValue = this.getOrCreateFieldValue(fieldInfo.id);
-          const numValues = fieldValue.values?.length ?? 1;
-          const dynamicFieldValueOptions = await this.getDynamicFieldValueOptionsAsync(0);
-          for (let index = 0; index < numValues; index++) {
-            dynamicOptions[index] = dynamicFieldValueOptions[fieldInfo.id];
-            if (dynamicOptions[index] === undefined) {
-              console.warn(`Could not get dynamic field options of field ${fieldInfo.name} id ${fieldInfo.id}`);
-              continue;
-            }
-            const values: string[] = this.getValueIfSingleOption(dynamicOptions[index]);
-            await this.updateDynamicFieldsAsync(fieldInfo, values, index);
+        const fieldValue = this.getOrCreateFieldValue(fieldInfo.id);
+        const numValues = fieldValue.values?.length ?? 1;
+        for (let index = 0; index < numValues; index++) {
+          dynamicOptions[index] = dynamicFieldValueOptions[fieldInfo.id];
+          if (dynamicOptions[index] === undefined) {
+            console.warn(`Could not get dynamic field options of field ${fieldInfo.name} id ${fieldInfo.id}`);
+            continue;
           }
-        } catch (err: unknown) {
-          this.templateState = TemplateState.HAS_ERROR;
-          this.templateErrorMessage = this.TEMPLATE_HAS_FAILED_TO_LOAD;
-          var consoleErrMsg: string = 'getDynamicFieldValueOptionsAsync failed';
-          if (err instanceof Error) {
-            consoleErrMsg = consoleErrMsg + ': ' + err.message;
-          }
-          console.error(consoleErrMsg);
-          throw err;
+          const values: string[] = this.getValueIfSingleOption(dynamicOptions[index]);
+          await this.updateDynamicFieldsAsync(fieldInfo, values, index);
         }
       }
     }


### PR DESCRIPTION
## Related to [Bug 674900](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/674900): Outlook Add-in should treat dynamic field evaluation failures as an empty list instead of bombing out

### Bug fixes
- **Reduce N→1 `getDynamicFieldValueOptionsAsync` calls on template load**: the call was
  inside a per-field loop, making one network request per base dynamic field even though
  the API returns all field values in a single response. It is now hoisted before the loop.
- **Show loader during full template load sequence**: `TemplateState.SHOW_TEMPLATE` was set
  after `getTemplateFieldsAsync` resolved, hiding the loader before
  `getDynamicFieldValueOptionsAsync` ran. The state transition is now deferred to just before
  `renderFieldsAsync` so the loader stays visible for the entire async sequence.

### Refactoring (`updateTemplateFieldInfoAsync`)
- Replace `some` + inner `isBaseDynamicField` re-check with a single `filter` using a type
  predicate, eliminating the duplicated predicate and the cast inside the loop.
- Early-return when there are no base dynamic fields, flattening the nesting.
- Extract per-field initialization into `initBaseDynamicFieldAsync`.