### PR TITLE
Fix dynamic field group rendering and vertical alignment issues

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -70,9 +70,10 @@ jobs:
         run: tar -czvf ./veracode/lf-documentation.tar.gz ./dist/lf-documentation
 
       - name: Veracode Upload And Scan (Static application security testing)
-        uses: veracode/veracode-uploadandscan-action@0.2.11
+        uses: veracode/uploadandscan-action@v0.2.2
         with:
           appname: "lf-ui-components"
+          version: "${{ github.run_id }}"
           createprofile: true
           filepath: "veracode"
           vid: "${{ secrets.VERACODE_API_ID }}"

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/dynamic-field/dynamic-field.component.html
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/dynamic-field/dynamic-field.component.html
@@ -1,7 +1,7 @@
 <!--Copyright (c) Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
-<mat-form-field [title]="title" appearance="outline" class="lf-field">
+<mat-form-field [title]="title" appearance="outline" class="lf-field lf-dropdown">
   <mat-select
     panelClass="lf-dropdown-overlay"
     [formControl]="formControl"

--- a/projects/ui-components/lf-metadata/field-components/lf-field-group/lf-field-group.component.ts
+++ b/projects/ui-components/lf-metadata/field-components/lf-field-group/lf-field-group.component.ts
@@ -259,7 +259,7 @@ export class LfFieldGroupComponent {
     this.fieldGroups.removeAt(index);
     const numIndices = this.fieldGroupControlsArray().length;
     const indicesChanged: number[] = [];
-    for (let tracker = index; tracker <= numIndices; tracker++) {
+    for (let tracker = index; tracker < numIndices; tracker++) {
       indicesChanged.push(tracker);
     }
     this.fieldValues.forEach((fieldValue) => {
@@ -285,7 +285,7 @@ export class LfFieldGroupComponent {
     const formGroup: FormGroup = new FormGroup({});
     const numIndices = this.fieldGroupControlsArray().length + 1;
     const indicesChanged: number[] = [];
-    for (let tracker = currentIndex + 1; tracker <= numIndices; tracker++) {
+    for (let tracker = currentIndex + 1; tracker < numIndices; tracker++) {
       indicesChanged.push(tracker);
     }
     this.fieldDefinitions.forEach((fieldDef) => {

--- a/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
+++ b/projects/ui-components/lf-metadata/lf-field-template-container/lf-field-template-container.component.ts
@@ -331,6 +331,7 @@ export class LfFieldTemplateContainerComponent extends LfFieldContainerDirective
         if (this.availableTemplates.length === 0) {
           this.templateState = TemplateState.DEFAULT;
         }
+        this.ref.markForCheck();
       } catch (err) {
         this.dropdownState = DropDownState.HAS_ERROR;
         this.templateSelected = undefined;


### PR DESCRIPTION

[Bug 678035](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/678035): [lf-ui-components] lf-field-template-container: Adding a group row a template with 1 existing row causes all groups to disappear
- **Bug fix**: Corrected off-by-one error in `lf-field-group.component.ts` (`onClickAdd` / `onClickDelete`) where `indicesChanged` included an out-of-bounds index, causing all group rows to disappear when adding a row in a dynamic field group template (e.g. Location Dynamic)

[Bug 670479](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/670479): [Office and Outlook Add-ins] Alignment is broken for dropdown list fields for metadata
- **Bug fix**: Added `lf-dropdown` class to `mat-form-field` in `dynamic-field.component.html` so CDN compensation styles are applied, fixing vertical alignment of dynamic field dropdowns

[Bug 675538](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/675538): [lf-ui-components] the template selector does not load on the first click after init
- **Bug fix**: Call `markForCheck()` after templates load in `onToggleDropdownAsync` so the template dropdown list renders on first open

 **CI**: Updated Veracode workflow task version
