### PR TITLE
 Fix: dynamic list field options not loaded correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Licensed under the MIT License. See LICENSE in the project root for license info
 
 - `[lf-field-template-container]`: Fixed `getDynamicFieldValueOptionsAsync` being called once per base dynamic field on template load, causing N redundant network requests. The call is now made once and the result shared across all fields.
 - `[lf-field-template-container]`: Fixed the loading indicator disappearing before all async work completed when loading a template with dynamic fields.
+- `[lf-field-template-container]`: Fixed `lf-list-field-component` showing static list values instead of the correct dynamic options.
 
 ## 21.1.0
 

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.html
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.html
@@ -9,7 +9,7 @@ Licensed under the MIT License. See LICENSE in the project root for license info
     (selectionChange)="onValueChanged()"
   >
     <mat-option>--</mat-option>
-    @for (listOption of (isDynamic ? dynamic_field_value_options : lf_field_info.listValues); track listOption) {
+    @for (listOption of isDynamic ? dynamic_field_value_options : lf_field_info.listValues; track listOption) {
       <mat-option [value]="listOption">
         {{ listOption }}
       </mat-option>

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.html
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.html
@@ -9,7 +9,7 @@ Licensed under the MIT License. See LICENSE in the project root for license info
     (selectionChange)="onValueChanged()"
   >
     <mat-option>--</mat-option>
-    @for (listOption of lf_field_info.listValues; track listOption) {
+    @for (listOption of (isDynamic ? dynamic_field_value_options : lf_field_info.listValues); track listOption) {
       <mat-option [value]="listOption">
         {{ listOption }}
       </mat-option>

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
@@ -6,11 +6,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ListFieldComponent } from './list-field.component';
 
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { LfFieldInfo } from '../../../utils/lf-field-types';
+import { LfFieldInfo, TemplateFieldInfo } from '../../../utils/lf-field-types';
 import { FieldType } from '@laserfiche/lf-ui-components/shared';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSelect, MatSelectModule } from '@angular/material/select';
+import { By } from '@angular/platform-browser';
 
 describe('ListFieldComponent', () => {
   let component: ListFieldComponent;
@@ -29,7 +29,6 @@ describe('ListFieldComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         ListFieldComponent,
-        BrowserAnimationsModule,
         FormsModule,
         MatFormFieldModule,
         MatSelectModule,
@@ -48,5 +47,49 @@ describe('ListFieldComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  function getRenderedOptionValues(): string[] {
+    const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
+    return matSelect.options.toArray()
+      .map((o) => o.value)
+      .filter((v) => v !== undefined && v !== null);
+  }
+
+  describe('list-field dropdown options', () => {
+    it('shows static listValues for a non-dynamic list field', () => {
+      component.lf_field_info = { ...listInfo, listValues: ['Option A', 'Option B'] };
+      fixture.detectChanges();
+
+      expect(getRenderedOptionValues()).toEqual(['Option A', 'Option B']);
+    });
+
+    it('shows dynamic options for a dynamic list field', () => {
+      const dynamicField: TemplateFieldInfo = {
+        ...listInfo,
+        listValues: ['Static A', 'Static B'],
+        rule: { ancestors: [] },
+      };
+      component.lf_field_info = dynamicField;
+      component.dynamic_field_value_options = ['Dynamic X', 'Dynamic Y'];
+      fixture.detectChanges();
+
+      expect(getRenderedOptionValues()).toEqual(['Dynamic X', 'Dynamic Y']);
+    });
+
+    it('does not show static listValues when the field is dynamic', () => {
+      const dynamicField: TemplateFieldInfo = {
+        ...listInfo,
+        listValues: ['Static A', 'Static B'],
+        rule: { ancestors: [] },
+      };
+      component.lf_field_info = dynamicField;
+      component.dynamic_field_value_options = ['Dynamic X', 'Dynamic Y'];
+      fixture.detectChanges();
+
+      const texts = getRenderedOptionValues();
+      expect(texts).not.toContain('Static A');
+      expect(texts).not.toContain('Static B');
+    });
   });
 });

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
@@ -27,13 +27,7 @@ describe('ListFieldComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        ListFieldComponent,
-        FormsModule,
-        MatFormFieldModule,
-        MatSelectModule,
-        ReactiveFormsModule,
-      ],
+      imports: [ListFieldComponent, FormsModule, MatFormFieldModule, MatSelectModule, ReactiveFormsModule],
     }).compileComponents();
   });
 
@@ -51,7 +45,8 @@ describe('ListFieldComponent', () => {
 
   function getRenderedOptionValues(): string[] {
     const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
-    return matSelect.options.toArray()
+    return matSelect.options
+      .toArray()
       .map((o) => o.value)
       .filter((v) => v !== undefined && v !== null);
   }


### PR DESCRIPTION
[Bug 678194](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/678194): [lf-ui-components] The dynamic field does not list the options correctly

- **Bug fix**: `ListFieldComponent` now uses `dynamic_field_value_options` when the field is
  dynamic, instead of always rendering the static `lf_field_info.listValues` — aligning with
  the same `isDynamic` gate used by all other field type components (text, number, date, etc.)
- **Tests**: Added unit tests covering the two behavioral cases — static list fields render
  `listValues`, dynamic list fields render `dynamic_field_value_options` and do not fall back
  to `listValues`
