### PR TITLE
Expose CSS custom properties for lf-field layout customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Licensed under the MIT License. See LICENSE in the project root for license info
 
 ## 21.1.1
 
+### Features
+
+- `[lf-field-container]`, `[lf-field-adhoc-container]`, `[lf-field-template-container]`: Added the following CSS custom properties, existing defaults unchanged:
+  - `--lf-field-height`
+  - `--lf-field-min-height`
+  - `--lf-field-subscript-display`
+
 ### Fixes
 
 - `[lf-field-template-container]`: Fixed `getDynamicFieldValueOptionsAsync` being called once per base dynamic field on template load, causing N redundant network requests. The call is now made once and the result shared across all fields.

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
@@ -117,7 +117,7 @@
 
 ::ng-deep mat-form-field.lf-field .mat-mdc-form-field-subscript-wrapper,
 ::ng-deep mat-form-field.lf-textarea .mat-mdc-form-field-subscript-wrapper {
-  display: flex;
+  display: var(--lf-field-subscript-display, flex);
   flex-direction: column;
 }
 
@@ -164,12 +164,12 @@
 }
 
 ::ng-deep .lf-field > .mat-mdc-text-field-wrapper > .mat-mdc-form-field-flex {
-  height: 28px;
+  height: var(--lf-field-height, 28px);
 }
 
 ::ng-deep .lf-field > .mat-mdc-text-field-wrapper > .mat-mdc-form-field-flex > .mat-mdc-form-field-infix {
   height: inherit;
-  min-height: var(--lf-field-infix-min-height, 0px);
+  min-height: var(--lf-field-min-height, 0px);
 }
 
 ::ng-deep

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/lf-field-base/lf-field-base.component.css
@@ -169,7 +169,7 @@
 
 ::ng-deep .lf-field > .mat-mdc-text-field-wrapper > .mat-mdc-form-field-flex > .mat-mdc-form-field-infix {
   height: inherit;
-  min-height: 0px;
+  min-height: var(--lf-field-infix-min-height, 0px);
 }
 
 ::ng-deep

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.html
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.html
@@ -9,7 +9,7 @@ Licensed under the MIT License. See LICENSE in the project root for license info
     (selectionChange)="onValueChanged()"
   >
     <mat-option>--</mat-option>
-    @for (listOption of isDynamic ? dynamic_field_value_options : lf_field_info.listValues; track listOption) {
+    @for (listOption of listOptions; track listOption) {
       <mat-option [value]="listOption">
         {{ listOption }}
       </mat-option>

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
@@ -9,8 +9,7 @@ import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { LfFieldInfo, TemplateFieldInfo } from '../../../utils/lf-field-types';
 import { FieldType } from '@laserfiche/lf-ui-components/shared';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelect, MatSelectModule } from '@angular/material/select';
-import { By } from '@angular/platform-browser';
+import { MatSelectModule } from '@angular/material/select';
 
 describe('ListFieldComponent', () => {
   let component: ListFieldComponent;
@@ -43,23 +42,14 @@ describe('ListFieldComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  function getRenderedOptionValues(): string[] {
-    const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
-    return matSelect.options
-      .toArray()
-      .map((o) => o.value)
-      .filter((v) => v !== undefined && v !== null);
-  }
-
-  describe('list-field dropdown options', () => {
-    it('shows static listValues for a non-dynamic list field', () => {
+  describe('listOptions', () => {
+    it('returns listValues for a non-dynamic list field', () => {
       component.lf_field_info = { ...listInfo, listValues: ['Option A', 'Option B'] };
-      fixture.detectChanges();
 
-      expect(getRenderedOptionValues()).toEqual(['Option A', 'Option B']);
+      expect(component.listOptions).toEqual(['Option A', 'Option B']);
     });
 
-    it('shows dynamic options for a dynamic list field', () => {
+    it('returns dynamic_field_value_options for a dynamic list field', () => {
       const dynamicField: TemplateFieldInfo = {
         ...listInfo,
         listValues: ['Static A', 'Static B'],
@@ -67,12 +57,11 @@ describe('ListFieldComponent', () => {
       };
       component.lf_field_info = dynamicField;
       component.dynamic_field_value_options = ['Dynamic X', 'Dynamic Y'];
-      fixture.detectChanges();
 
-      expect(getRenderedOptionValues()).toEqual(['Dynamic X', 'Dynamic Y']);
+      expect(component.listOptions).toEqual(['Dynamic X', 'Dynamic Y']);
     });
 
-    it('does not show static listValues when the field is dynamic', () => {
+    it('does not return static listValues when the field is dynamic', () => {
       const dynamicField: TemplateFieldInfo = {
         ...listInfo,
         listValues: ['Static A', 'Static B'],
@@ -80,11 +69,9 @@ describe('ListFieldComponent', () => {
       };
       component.lf_field_info = dynamicField;
       component.dynamic_field_value_options = ['Dynamic X', 'Dynamic Y'];
-      fixture.detectChanges();
 
-      const texts = getRenderedOptionValues();
-      expect(texts).not.toContain('Static A');
-      expect(texts).not.toContain('Static B');
+      expect(component.listOptions).not.toContain('Static A');
+      expect(component.listOptions).not.toContain('Static B');
     });
   });
 });

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.spec.ts
@@ -9,7 +9,8 @@ import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { LfFieldInfo, TemplateFieldInfo } from '../../../utils/lf-field-types';
 import { FieldType } from '@laserfiche/lf-ui-components/shared';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
+import { MatSelect, MatSelectModule } from '@angular/material/select';
+import { By } from '@angular/platform-browser';
 
 describe('ListFieldComponent', () => {
   let component: ListFieldComponent;
@@ -40,6 +41,26 @@ describe('ListFieldComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('template rendering', () => {
+    it('renders mat-option elements matching listOptions', () => {
+      const dynamicField: TemplateFieldInfo = {
+        ...listInfo,
+        listValues: ['Static A', 'Static B'],
+        rule: { ancestors: [] },
+      };
+      component.lf_field_info = dynamicField;
+      component.dynamic_field_value_options = ['Dynamic X', 'Dynamic Y'];
+      fixture.detectChanges();
+
+      const matSelect = fixture.debugElement.query(By.directive(MatSelect)).componentInstance as MatSelect;
+      const renderedValues = matSelect.options
+        .toArray()
+        .map((o) => o.value)
+        .filter((v) => v != null);
+      expect(renderedValues).toEqual(component.listOptions);
+    });
   });
 
   describe('listOptions', () => {

--- a/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.ts
+++ b/projects/ui-components/lf-metadata/field-components/field-base-parts/lf-field-base/list-field/list-field.component.ts
@@ -39,6 +39,10 @@ export class ListFieldComponent extends BaseFieldDirective implements OnInit {
     return [];
   }
 
+  get listOptions(): string[] | undefined {
+    return this.isDynamic ? this.dynamic_field_value_options : this.lf_field_info.listValues;
+  }
+
   protected override fieldOnValueChanged(): void {
     const currentValue = this.lf_field_form_control.value;
     this.lf_field_form_control.setValue(currentValue ?? '');


### PR DESCRIPTION
## [Bug 670479](https://v-dev-tfs.laserfiche.com/DefaultCollection/Cloud/_workitems/edit/670479): [Office and Outlook Add-ins] Alignment is broken for dropdown list fields for metadata

Consumers currently need `::ng-deep` to override field height and subscript visibility.
This PR exposes CSS custom properties so those overrides can be applied without `::ng-deep`:

- `--lf-field-height` (default `28px`)
- `--lf-field-min-height` (default `0px`)
- `--lf-field-subscript-display` (default `flex`)

### Refactor
- `[lf-list-field-component]`: Moved dynamic vs. static list option resolution from the
  template into a `listOptions` getter
