### PR TITLE
 Fix CDK 21 virtual scroll regression and add local dev tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [AGENTS.md](AGENTS.md) for detailed workspace structure, validation guidance, edit boundaries, and naming conventions.
+
+## Commands
+
+```powershell
+# Install dependencies
+npm ci
+
+# Build
+npm run build-ui-components-prod     # library (production)
+npm run build-ui-components-dev      # library (development, faster)
+npm run build-ui-components-dev-watch  # library watch mode
+npm run build-lf-documentation-prod  # documentation app
+npm run build-lf-cdn-prod            # CDN bundle
+
+# Serve documentation locally (interactive development)
+npm run serve                        # http://127.0.0.1:4200
+
+# Watch mode for active UI development (run both in separate terminals)
+npm run build-ui-components-dev-watch
+npm run build-lf-documentation-dev-watch
+
+# Test (Vitest + Playwright Chromium)
+npm run test
+npx playwright install chromium      # if browser is missing
+
+# Lint & format
+npm run lint
+npm run format:check
+
+# Full local CI parity
+.\build-test-locally.ps1
+
+# Build and pack for local install in another repo
+.\build-local-npm-package.ps1
+# Output: dist/ui-components/laserfiche-lf-ui-components-*.tgz
+```
+
+To run a single test file:
+```powershell
+npx vitest --browser.enabled path/to/file.spec.ts
+```
+
+## Architecture
+
+This is an Angular monorepo workspace with three projects:
+
+### `projects/ui-components` — publishable library (`@laserfiche/lf-ui-components`)
+
+The primary package entry point (`entry.ts`) is a dummy export. The real public API is split across **secondary entry points**, each with its own `ng-package.json` and `*-public-api.ts` barrel file:
+
+| Entry point | Import path |
+|---|---|
+| lf-login | `@laserfiche/lf-ui-components/lf-login` |
+| lf-checklist | `@laserfiche/lf-ui-components/lf-checklist` |
+| lf-metadata | `@laserfiche/lf-ui-components/lf-metadata` |
+| lf-repository-browser | `@laserfiche/lf-ui-components/lf-repository-browser` |
+| lf-tags | `@laserfiche/lf-ui-components/lf-tags` |
+| lf-user-feedback | `@laserfiche/lf-ui-components/lf-user-feedback` |
+| lf-selection-list | `@laserfiche/lf-ui-components/lf-selection-list` |
+| shared | `@laserfiche/lf-ui-components/shared` |
+
+`internal-shared/` contains shared components and localization services that are consumed internally but not exposed in the published package.
+
+### `projects/lf-cdn` — CDN bundle
+
+Registers all ui-components as Angular Elements (custom HTML elements) and bundles them into a single `lf-ui-components.js` for CDN delivery. This enables usage in non-Angular frameworks (React, Vue, plain HTML).
+
+### `projects/lf-documentation` — documentation app
+
+Interactive demo and manual validation surface for all components. Prefer this project for verifying UI changes visually before submitting a PR.
+
+### `projects/styles` — SCSS themes
+
+Two themes compiled to CSS:
+- `lf-laserfiche-lite.scss` → Laserfiche branding
+- `lf-ms-office-lite.scss` → Microsoft Office styling
+
+These are compiled separately via `npm run sass-lf` / `npm run sass-ms` and are included in both the CDN bundle and the documentation app.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ npm run format:check
 ```
 
 To run a single test file:
+
 ```powershell
 npx vitest --browser.enabled path/to/file.spec.ts
 ```
@@ -53,16 +54,16 @@ This is an Angular monorepo workspace with three projects:
 
 The primary package entry point (`entry.ts`) is a dummy export. The real public API is split across **secondary entry points**, each with its own `ng-package.json` and `*-public-api.ts` barrel file:
 
-| Entry point | Import path |
-|---|---|
-| lf-login | `@laserfiche/lf-ui-components/lf-login` |
-| lf-checklist | `@laserfiche/lf-ui-components/lf-checklist` |
-| lf-metadata | `@laserfiche/lf-ui-components/lf-metadata` |
+| Entry point           | Import path                                          |
+| --------------------- | ---------------------------------------------------- |
+| lf-login              | `@laserfiche/lf-ui-components/lf-login`              |
+| lf-checklist          | `@laserfiche/lf-ui-components/lf-checklist`          |
+| lf-metadata           | `@laserfiche/lf-ui-components/lf-metadata`           |
 | lf-repository-browser | `@laserfiche/lf-ui-components/lf-repository-browser` |
-| lf-tags | `@laserfiche/lf-ui-components/lf-tags` |
-| lf-user-feedback | `@laserfiche/lf-ui-components/lf-user-feedback` |
-| lf-selection-list | `@laserfiche/lf-ui-components/lf-selection-list` |
-| shared | `@laserfiche/lf-ui-components/shared` |
+| lf-tags               | `@laserfiche/lf-ui-components/lf-tags`               |
+| lf-user-feedback      | `@laserfiche/lf-ui-components/lf-user-feedback`      |
+| lf-selection-list     | `@laserfiche/lf-ui-components/lf-selection-list`     |
+| shared                | `@laserfiche/lf-ui-components/shared`                |
 
 `internal-shared/` contains shared components and localization services that are consumed internally but not exposed in the published package.
 
@@ -77,6 +78,7 @@ Interactive demo and manual validation surface for all components. Prefer this p
 ### `projects/styles` — SCSS themes
 
 Two themes compiled to CSS:
+
 - `lf-laserfiche-lite.scss` → Laserfiche branding
 - `lf-ms-office-lite.scss` → Microsoft Office styling
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ We welcome contributions and feedback. Please follow our [contributing guideline
    - This command will generate the CDN entry file `dist/lf-cdn/lf-ui-components.js`.
    - If need to output the CDN entry file to a different directory or project for said project local test, change `SCRIPT_DEST` in the root `gulpfile.js`. **Important**: don't commit this change to Pull Request
 
+### Build and install lf-ui-components NPM package locally
+
+Run the script to build the full package (including CDN bundle and CSS assets):
+
+```powershell
+.\build-local-npm-package.ps1
+```
+
+This produces `./dist/ui-components/laserfiche-lf-ui-components-[MajorVersion].0.0.tgz`. To install it in another repo:
+
+```powershell
+npm install C:\git\lf-ui-components\dist\ui-components\laserfiche-lf-ui-components-[MajorVersion].0.0.tgz
+```
+
 ### Build types-lf-ui-components NPM
 
 This will create a package with version [MajorVersion].0.0. If you would like to update the version, change the version at `./types-lf-ui-components-publish/package.json`.

--- a/build-local-npm-package.ps1
+++ b/build-local-npm-package.ps1
@@ -14,16 +14,16 @@ $flatpickrBlock = "`n/* `n$license`nThe following styles are copied from flatpic
 Add-Content dist/lf-documentation/browser/lf-laserfiche-lite.css $flatpickrBlock
 Add-Content dist/lf-documentation/browser/lf-ms-office-lite.css $flatpickrBlock
 
-cp node_modules/@angular/material/prebuilt-themes/indigo-pink.css dist/ui-components/cdn/
-mv dist/lf-cdn/browser/lf-ui-components.js dist/ui-components/cdn/
-mv dist/lf-cdn/browser/lf-ui-components.js.map dist/ui-components/cdn/
-cp dist/lf-documentation/browser/lf-laserfiche-lite.css dist/ui-components/cdn/
-cp dist/lf-documentation/browser/lf-laserfiche-lite.css.map dist/ui-components/cdn/
-cp dist/lf-documentation/browser/lf-ms-office-lite.css dist/ui-components/cdn/
-cp dist/lf-documentation/browser/lf-ms-office-lite.css.map dist/ui-components/cdn/
+Copy-Item node_modules/@angular/material/prebuilt-themes/indigo-pink.css dist/ui-components/cdn/
+Move-Item dist/lf-cdn/browser/lf-ui-components.js dist/ui-components/cdn/
+Move-Item dist/lf-cdn/browser/lf-ui-components.js.map dist/ui-components/cdn/
+Copy-Item dist/lf-documentation/browser/lf-laserfiche-lite.css dist/ui-components/cdn/
+Copy-Item dist/lf-documentation/browser/lf-laserfiche-lite.css.map dist/ui-components/cdn/
+Copy-Item dist/lf-documentation/browser/lf-ms-office-lite.css dist/ui-components/cdn/
+Copy-Item dist/lf-documentation/browser/lf-ms-office-lite.css.map dist/ui-components/cdn/
 
-cp README.md dist/ui-components/
+Copy-Item README.md dist/ui-components/
 
-cd dist/ui-components
+Push-Location dist/ui-components
 npm pack
-cd ../..
+Pop-Location

--- a/build-local-npm-package.ps1
+++ b/build-local-npm-package.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = 'Stop'
+
 npm run build-ui-components-prod
 npm run create-lf-cdn
 npm run build-lf-documentation-prod

--- a/build-local-npm-package.ps1
+++ b/build-local-npm-package.ps1
@@ -1,0 +1,19 @@
+npm run build-ui-components-prod
+npm run create-lf-cdn
+npm run build-lf-documentation-prod
+
+New-Item -ItemType Directory -Force -Path dist/ui-components/cdn | Out-Null
+
+cp node_modules/@angular/material/prebuilt-themes/indigo-pink.css dist/ui-components/cdn/
+mv dist/lf-cdn/browser/lf-ui-components.js dist/ui-components/cdn/
+mv dist/lf-cdn/browser/lf-ui-components.js.map dist/ui-components/cdn/
+cp dist/lf-documentation/browser/lf-laserfiche-lite.css dist/ui-components/cdn/
+cp dist/lf-documentation/browser/lf-laserfiche-lite.css.map dist/ui-components/cdn/
+cp dist/lf-documentation/browser/lf-ms-office-lite.css dist/ui-components/cdn/
+cp dist/lf-documentation/browser/lf-ms-office-lite.css.map dist/ui-components/cdn/
+
+cp README.md dist/ui-components/
+
+cd dist/ui-components
+npm pack
+cd ../..

--- a/build-local-npm-package.ps1
+++ b/build-local-npm-package.ps1
@@ -4,6 +4,14 @@ npm run build-lf-documentation-prod
 
 New-Item -ItemType Directory -Force -Path dist/ui-components/cdn | Out-Null
 
+# Append flatpickr styles to theme CSS files (mirrors CI pipeline)
+$flatpickrCss = Get-Content node_modules/flatpickr/dist/flatpickr.min.css -Raw
+$license = Get-Content LICENSE -Raw
+$flatpickrBlock = "`n/* `n$license`nThe following styles are copied from flatpickr.min.css */`n$flatpickrCss"
+
+Add-Content dist/lf-documentation/browser/lf-laserfiche-lite.css $flatpickrBlock
+Add-Content dist/lf-documentation/browser/lf-ms-office-lite.css $flatpickrBlock
+
 cp node_modules/@angular/material/prebuilt-themes/indigo-pink.css dist/ui-components/cdn/
 mv dist/lf-cdn/browser/lf-ui-components.js dist/ui-components/cdn/
 mv dist/lf-cdn/browser/lf-ui-components.js.map dist/ui-components/cdn/

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.spec.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.spec.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { Renderer2 } from '@angular/core';
 import { LfManagedVirtualScrollDirective, LfManagedVirtualScrollStrategy } from './lf-managed-virtual-scroll.directive';
+
+function fakeRenderer() {
+  return { setStyle: vi.fn() } as unknown as Renderer2;
+}
 
 describe('LfManagedVirtualScrollStrategy', () => {
   function fakeViewport(scrollOffset = 0, orientation: 'vertical' | 'horizontal' = 'vertical') {
@@ -28,7 +33,7 @@ describe('LfManagedVirtualScrollStrategy', () => {
   }
 
   it('emits the scroll index based on scroll offset / item size', () => {
-    const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+    const strategy = new LfManagedVirtualScrollStrategy(() => 42, fakeRenderer());
     const viewport = fakeViewport(42 * 100);
     strategy.attach(viewport);
 
@@ -41,7 +46,7 @@ describe('LfManagedVirtualScrollStrategy', () => {
   });
 
   it('does not emit duplicate scroll indices', () => {
-    const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+    const strategy = new LfManagedVirtualScrollStrategy(() => 42, fakeRenderer());
     const viewport = fakeViewport(42 * 50);
     strategy.attach(viewport);
 
@@ -55,7 +60,7 @@ describe('LfManagedVirtualScrollStrategy', () => {
   });
 
   it('does nothing on rendered offset change so the consumer-managed offset is preserved', () => {
-    const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+    const strategy = new LfManagedVirtualScrollStrategy(() => 42, fakeRenderer());
     const viewport = fakeViewport();
     strategy.attach(viewport);
 
@@ -65,7 +70,7 @@ describe('LfManagedVirtualScrollStrategy', () => {
   });
 
   it('scrolls to the offset corresponding to the requested index', () => {
-    const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+    const strategy = new LfManagedVirtualScrollStrategy(() => 42, fakeRenderer());
     const viewport = fakeViewport();
     strategy.attach(viewport);
 
@@ -75,7 +80,7 @@ describe('LfManagedVirtualScrollStrategy', () => {
   });
 
   it('does nothing while detached', () => {
-    const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+    const strategy = new LfManagedVirtualScrollStrategy(() => 42, fakeRenderer());
     const emissions: number[] = [];
     strategy.scrolledIndexChange.subscribe((index) => emissions.push(index));
 
@@ -86,7 +91,7 @@ describe('LfManagedVirtualScrollStrategy', () => {
   });
 
   it('ignores invalid item sizes', () => {
-    const strategy = new LfManagedVirtualScrollStrategy(() => 0);
+    const strategy = new LfManagedVirtualScrollStrategy(() => 0, fakeRenderer());
     const viewport = fakeViewport(42 * 100);
     strategy.attach(viewport);
 
@@ -100,48 +105,54 @@ describe('LfManagedVirtualScrollStrategy', () => {
 
   describe('applyRenderedOffset', () => {
     it('sets translateY on the content wrapper for a vertical viewport', () => {
-      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+      const renderer = fakeRenderer();
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42, renderer);
       const { viewport, contentWrapper } = fakeViewportWithWrapper('vertical');
       strategy.attach(viewport);
 
       strategy.applyRenderedOffset(420);
 
-      expect(contentWrapper.style.transform).toBe('translateY(420px)');
+      expect(renderer.setStyle).toHaveBeenCalledWith(contentWrapper, 'transform', 'translateY(420px)');
     });
 
     it('sets translateX on the content wrapper for a horizontal viewport', () => {
-      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+      const renderer = fakeRenderer();
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42, renderer);
       const { viewport, contentWrapper } = fakeViewportWithWrapper('horizontal');
       strategy.attach(viewport);
 
       strategy.applyRenderedOffset(840);
 
-      expect(contentWrapper.style.transform).toBe('translateX(840px)');
+      expect(renderer.setStyle).toHaveBeenCalledWith(contentWrapper, 'transform', 'translateX(840px)');
     });
 
     it('is a no-op when the content wrapper element is not found', () => {
-      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+      const renderer = fakeRenderer();
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42, renderer);
       strategy.attach(fakeViewport());
 
-      expect(() => strategy.applyRenderedOffset(420)).not.toThrow();
+      strategy.applyRenderedOffset(420);
+
+      expect(renderer.setStyle).not.toHaveBeenCalled();
     });
 
     it('is a no-op after detach', () => {
-      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
-      const { viewport, contentWrapper } = fakeViewportWithWrapper();
+      const renderer = fakeRenderer();
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42, renderer);
+      const { viewport } = fakeViewportWithWrapper();
       strategy.attach(viewport);
       strategy.detach();
 
       strategy.applyRenderedOffset(420);
 
-      expect(contentWrapper.style.transform).toBe('');
+      expect(renderer.setStyle).not.toHaveBeenCalled();
     });
   });
 });
 
 describe('LfManagedVirtualScrollDirective', () => {
   it('exposes a LfManagedVirtualScrollStrategy whose item size is driven by the directive input', () => {
-    const directive = new LfManagedVirtualScrollDirective();
+    const directive = new LfManagedVirtualScrollDirective(fakeRenderer());
     directive.itemSize = 56;
 
     const viewport = {

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.spec.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.spec.ts
@@ -5,11 +5,26 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { LfManagedVirtualScrollDirective, LfManagedVirtualScrollStrategy } from './lf-managed-virtual-scroll.directive';
 
 describe('LfManagedVirtualScrollStrategy', () => {
-  function fakeViewport(scrollOffset = 0) {
+  function fakeViewport(scrollOffset = 0, orientation: 'vertical' | 'horizontal' = 'vertical') {
     return {
       measureScrollOffset: () => scrollOffset,
       scrollToOffset: vi.fn(),
+      orientation,
+      elementRef: { nativeElement: { querySelector: () => null } },
     } as unknown as CdkVirtualScrollViewport;
+  }
+
+  function fakeViewportWithWrapper(orientation: 'vertical' | 'horizontal' = 'vertical') {
+    const contentWrapper = document.createElement('div');
+    return {
+      viewport: {
+        measureScrollOffset: () => 0,
+        scrollToOffset: vi.fn(),
+        orientation,
+        elementRef: { nativeElement: { querySelector: () => contentWrapper } },
+      } as unknown as CdkVirtualScrollViewport,
+      contentWrapper,
+    };
   }
 
   it('emits the scroll index based on scroll offset / item size', () => {
@@ -82,6 +97,46 @@ describe('LfManagedVirtualScrollStrategy', () => {
 
     expect(emissions).toEqual([]);
   });
+
+  describe('applyRenderedOffset', () => {
+    it('sets translateY on the content wrapper for a vertical viewport', () => {
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+      const { viewport, contentWrapper } = fakeViewportWithWrapper('vertical');
+      strategy.attach(viewport);
+
+      strategy.applyRenderedOffset(420);
+
+      expect(contentWrapper.style.transform).toBe('translateY(420px)');
+    });
+
+    it('sets translateX on the content wrapper for a horizontal viewport', () => {
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+      const { viewport, contentWrapper } = fakeViewportWithWrapper('horizontal');
+      strategy.attach(viewport);
+
+      strategy.applyRenderedOffset(840);
+
+      expect(contentWrapper.style.transform).toBe('translateX(840px)');
+    });
+
+    it('is a no-op when the content wrapper element is not found', () => {
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+      strategy.attach(fakeViewport());
+
+      expect(() => strategy.applyRenderedOffset(420)).not.toThrow();
+    });
+
+    it('is a no-op after detach', () => {
+      const strategy = new LfManagedVirtualScrollStrategy(() => 42);
+      const { viewport, contentWrapper } = fakeViewportWithWrapper();
+      strategy.attach(viewport);
+      strategy.detach();
+
+      strategy.applyRenderedOffset(420);
+
+      expect(contentWrapper.style.transform).toBe('');
+    });
+  });
 });
 
 describe('LfManagedVirtualScrollDirective', () => {
@@ -92,6 +147,8 @@ describe('LfManagedVirtualScrollDirective', () => {
     const viewport = {
       measureScrollOffset: () => 56 * 7,
       scrollToOffset: vi.fn(),
+      orientation: 'vertical',
+      elementRef: { nativeElement: { querySelector: () => null } },
     } as unknown as CdkVirtualScrollViewport;
 
     directive.scrollStrategy.attach(viewport);

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.spec.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.spec.ts
@@ -3,6 +3,7 @@
 
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Renderer2 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { LfManagedVirtualScrollDirective, LfManagedVirtualScrollStrategy } from './lf-managed-virtual-scroll.directive';
 
 function fakeRenderer() {
@@ -151,8 +152,14 @@ describe('LfManagedVirtualScrollStrategy', () => {
 });
 
 describe('LfManagedVirtualScrollDirective', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: Renderer2, useValue: fakeRenderer() }],
+    });
+  });
+
   it('exposes a LfManagedVirtualScrollStrategy whose item size is driven by the directive input', () => {
-    const directive = new LfManagedVirtualScrollDirective(fakeRenderer());
+    const directive = TestBed.runInInjectionContext(() => new LfManagedVirtualScrollDirective());
     directive.itemSize = 56;
 
     const viewport = {

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
@@ -29,7 +29,7 @@ export class LfManagedVirtualScrollStrategy implements VirtualScrollStrategy {
 
   constructor(
     private readonly getItemSize: () => number,
-    private readonly renderer: Renderer2,
+    private readonly renderer: Renderer2
   ) {}
 
   attach(viewport: CdkVirtualScrollViewport): void {

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-import { Directive, Input, Renderer2, forwardRef, numberAttribute } from '@angular/core';
+import { Directive, Input, Renderer2, forwardRef, inject, numberAttribute } from '@angular/core';
 import { CdkVirtualScrollViewport, VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy } from '@angular/cdk/scrolling';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
@@ -128,7 +128,7 @@ export class LfManagedVirtualScrollDirective {
 
   readonly scrollStrategy: LfManagedVirtualScrollStrategy;
 
-  constructor(renderer: Renderer2) {
-    this.scrollStrategy = new LfManagedVirtualScrollStrategy(() => this.itemSize, renderer);
+  constructor() {
+    this.scrollStrategy = new LfManagedVirtualScrollStrategy(() => this.itemSize, inject(Renderer2));
   }
 }

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-import { Directive, Input, forwardRef, numberAttribute } from '@angular/core';
+import { Directive, Input, Renderer2, forwardRef, numberAttribute } from '@angular/core';
 import { CdkVirtualScrollViewport, VIRTUAL_SCROLL_STRATEGY, VirtualScrollStrategy } from '@angular/cdk/scrolling';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
@@ -27,7 +27,10 @@ export class LfManagedVirtualScrollStrategy implements VirtualScrollStrategy {
   private _viewport: CdkVirtualScrollViewport | null = null;
   private _contentWrapper: HTMLElement | null = null;
 
-  constructor(private readonly getItemSize: () => number) {}
+  constructor(
+    private readonly getItemSize: () => number,
+    private readonly renderer: Renderer2,
+  ) {}
 
   attach(viewport: CdkVirtualScrollViewport): void {
     this._viewport = viewport;
@@ -43,14 +46,16 @@ export class LfManagedVirtualScrollStrategy implements VirtualScrollStrategy {
   }
 
   /**
-   * Writes `style.transform` on the CDK content wrapper synchronously.
+   * Writes `style.transform` on the CDK content wrapper synchronously via `Renderer2`.
    *
    * CDK 21 regression: `_markChangeDetectionNeeded` skips re-scheduling when
    * `_changeDetectionNeeded` is already `true`, so rapid `offsetChange` emissions
    * can miss the async DOM update. Call this after `setRenderedContentOffset` to
    * guarantee the transform is applied regardless of CDK's internal signal state.
+   * TODO: remove once https://github.com/angular/components/issues tracks a fix for
+   * the `_changeDetectionNeeded` signal not re-firing after `afterNextRender` resets it.
    *
-   * Note: RTL negation for horizontal viewports is not replicated here — the
+   * Note: RTL negation for horizontal viewports is not replicated here — this
    * component always uses the default vertical orientation.
    */
   applyRenderedOffset(offset: number): void {
@@ -58,7 +63,7 @@ export class LfManagedVirtualScrollStrategy implements VirtualScrollStrategy {
       return;
     }
     const axis = this._viewport.orientation === 'horizontal' ? 'X' : 'Y';
-    this._contentWrapper.style.transform = `translate${axis}(${offset}px)`;
+    this.renderer.setStyle(this._contentWrapper, 'transform', `translate${axis}(${offset}px)`);
   }
 
   onContentScrolled(): void {
@@ -122,5 +127,9 @@ export class LfManagedVirtualScrollStrategy implements VirtualScrollStrategy {
 export class LfManagedVirtualScrollDirective {
   @Input({ alias: 'lfManagedItemSize', transform: numberAttribute }) itemSize = 42;
 
-  readonly scrollStrategy = new LfManagedVirtualScrollStrategy(() => this.itemSize);
+  readonly scrollStrategy: LfManagedVirtualScrollStrategy;
+
+  constructor(renderer: Renderer2) {
+    this.scrollStrategy = new LfManagedVirtualScrollStrategy(() => this.itemSize, renderer);
+  }
 }

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
@@ -52,8 +52,7 @@ export class LfManagedVirtualScrollStrategy implements VirtualScrollStrategy {
    * `_changeDetectionNeeded` is already `true`, so rapid `offsetChange` emissions
    * can miss the async DOM update. Call this after `setRenderedContentOffset` to
    * guarantee the transform is applied regardless of CDK's internal signal state.
-   * TODO: remove once https://github.com/angular/components/issues tracks a fix for
-   * the `_changeDetectionNeeded` signal not re-firing after `afterNextRender` resets it.
+   * TODO: remove once https://github.com/angular/components/issues/33484 is resolved.
    *
    * Note: RTL negation for horizontal viewports is not replicated here — this
    * component always uses the default vertical orientation.

--- a/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
+++ b/projects/ui-components/lf-selection-list/lf-managed-virtual-scroll.directive.ts
@@ -25,16 +25,40 @@ export class LfManagedVirtualScrollStrategy implements VirtualScrollStrategy {
   readonly scrolledIndexChange: Observable<number> = this._scrolledIndexChange.pipe(distinctUntilChanged());
 
   private _viewport: CdkVirtualScrollViewport | null = null;
+  private _contentWrapper: HTMLElement | null = null;
 
   constructor(private readonly getItemSize: () => number) {}
 
   attach(viewport: CdkVirtualScrollViewport): void {
     this._viewport = viewport;
+    this._contentWrapper = viewport.elementRef.nativeElement.querySelector(
+      '.cdk-virtual-scroll-content-wrapper'
+    ) as HTMLElement | null;
   }
 
   detach(): void {
     this._scrolledIndexChange.complete();
     this._viewport = null;
+    this._contentWrapper = null;
+  }
+
+  /**
+   * Writes `style.transform` on the CDK content wrapper synchronously.
+   *
+   * CDK 21 regression: `_markChangeDetectionNeeded` skips re-scheduling when
+   * `_changeDetectionNeeded` is already `true`, so rapid `offsetChange` emissions
+   * can miss the async DOM update. Call this after `setRenderedContentOffset` to
+   * guarantee the transform is applied regardless of CDK's internal signal state.
+   *
+   * Note: RTL negation for horizontal viewports is not replicated here — the
+   * component always uses the default vertical orientation.
+   */
+  applyRenderedOffset(offset: number): void {
+    if (!this._contentWrapper || !this._viewport) {
+      return;
+    }
+    const axis = this._viewport.orientation === 'horizontal' ? 'X' : 'Y';
+    this._contentWrapper.style.transform = `translate${axis}(${offset}px)`;
   }
 
   onContentScrolled(): void {

--- a/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
+++ b/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
@@ -219,8 +219,18 @@ export class LfSelectionListComponent implements AfterViewInit, OnDestroy {
       this.matTables?.last?.renderRows();
       this.ref.detectChanges();
     });
+    // Resolved once at init to avoid a querySelector on every offsetChange emission.
+    const contentWrapper = this.viewport?.elementRef.nativeElement.querySelector(
+      '.cdk-virtual-scroll-content-wrapper',
+    ) as HTMLElement | null;
     const dataOffsetSub = this.dataSource.offsetChange.subscribe((offset) => {
       this.viewport?.setRenderedContentOffset(offset);
+      // CDK 21: _markChangeDetectionNeeded skips re-firing when _changeDetectionNeeded is already
+      // true, so rapid emissions miss the DOM update. Write synchronously as the authoritative update.
+      if (contentWrapper) {
+        const axis = this.viewport?.orientation === 'horizontal' ? 'X' : 'Y';
+        contentWrapper.style.transform = `translate${axis}(${offset}px)`;
+      }
       this.ref.detectChanges();
     });
     this.allSubscriptions?.add(dataSourceSub);

--- a/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
+++ b/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
@@ -221,7 +221,7 @@ export class LfSelectionListComponent implements AfterViewInit, OnDestroy {
     });
     // Resolved once at init to avoid a querySelector on every offsetChange emission.
     const contentWrapper = this.viewport?.elementRef.nativeElement.querySelector(
-      '.cdk-virtual-scroll-content-wrapper',
+      '.cdk-virtual-scroll-content-wrapper'
     ) as HTMLElement | null;
     const dataOffsetSub = this.dataSource.offsetChange.subscribe((offset) => {
       this.viewport?.setRenderedContentOffset(offset);

--- a/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
+++ b/projects/ui-components/lf-selection-list/lf-selection-list.component.ts
@@ -170,6 +170,8 @@ export class LfSelectionListComponent implements AfterViewInit, OnDestroy {
   /** @internal */
   @ViewChild(CdkVirtualScrollViewport) viewport?: CdkVirtualScrollViewport;
   /** @internal */
+  @ViewChild(LfManagedVirtualScrollDirective) private scrollDirective?: LfManagedVirtualScrollDirective;
+  /** @internal */
   @ViewChild('matTable', { read: ElementRef }) matTable?: ElementRef;
   /** @internal */
   @ViewChildren(MatTable) matTables?: QueryList<MatTable<ILfSelectable>>;
@@ -219,18 +221,9 @@ export class LfSelectionListComponent implements AfterViewInit, OnDestroy {
       this.matTables?.last?.renderRows();
       this.ref.detectChanges();
     });
-    // Resolved once at init to avoid a querySelector on every offsetChange emission.
-    const contentWrapper = this.viewport?.elementRef.nativeElement.querySelector(
-      '.cdk-virtual-scroll-content-wrapper'
-    ) as HTMLElement | null;
     const dataOffsetSub = this.dataSource.offsetChange.subscribe((offset) => {
       this.viewport?.setRenderedContentOffset(offset);
-      // CDK 21: _markChangeDetectionNeeded skips re-firing when _changeDetectionNeeded is already
-      // true, so rapid emissions miss the DOM update. Write synchronously as the authoritative update.
-      if (contentWrapper) {
-        const axis = this.viewport?.orientation === 'horizontal' ? 'X' : 'Y';
-        contentWrapper.style.transform = `translate${axis}(${offset}px)`;
-      }
+      this.scrollDirective?.scrollStrategy.applyRenderedOffset(offset);
       this.ref.detectChanges();
     });
     this.allSubscriptions?.add(dataSourceSub);


### PR DESCRIPTION
## [Bug 674906](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/674906): [outlook add-in] ui-components - Folder Browser. The view jumps while scrolling large folder lists in folder browser

- **Bug fix**: Resolved CDK 21 regression in `LfSelectionListComponent` where rapid `offsetChange` emissions silently dropped DOM updates because `_markChangeDetectionNeeded` skips re-scheduling when its signal is already `true`; moved the synchronous `style.transform` workaround into `LfManagedVirtualScrollStrategy.applyRenderedOffset()` on the directive where it belongs
- **Tooling**: Added `build-local-npm-package.ps1` to assemble the full publishable package locally (CDN bundle, CSS assets, `dist/ui-components/cdn/`) and pack it as a `.tgz` for install in a consumer repo
- **Docs**: Added `CLAUDE.md` with commands and architecture overview, referencing `AGENTS.md`; updated `README.md` with a "Build and install lf-ui-components NPM package locally" section
